### PR TITLE
feat: Added support for passthru query result

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ queryResult = {
     one: 1,     // single-row result is expected;
     many: 2,    // multi-row result is expected;
     none: 4,    // no rows expected;
-    any: 6      // (default) = many|none = any result.
+    any: 6,      // (default) = many|none = any result.
+    passthru: 8  // return original pg result
 };
 ```
 
@@ -433,6 +434,7 @@ db.none(query, values); // expects no rows
 db.any(query, values); // expects anything, same as `manyOrNone`
 db.oneOrNone(query, values); // expects 1 or 0 rows
 db.manyOrNone(query, values); // expects anything, same as `any`
+db.passthru(query, values); // returns original pg result
 ```
 You can add your own methods to this protocol via the [extend](#extend) event.  
 
@@ -442,6 +444,7 @@ Each query function resolves its **data** object according to the `qrm` that was
 * `one` - **data** is a single object. If the query returns no data or more than one row of data, it is rejected.
 * `many` - **data** is an array of objects. If the query returns no rows, it is rejected.
 * `one` | `none` - **data** is `null`, if no data was returned; or a single object, if there was one row of data returned.
+* `passthru` - ***data** is always `result` object returned by the pg library. No checks or modifications are done.
 
 If the query returns more than one row of data, the query is rejected.
 * `many` | `none` - **data** is an array of objects. When no rows are returned, **data** is an empty array.

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ queryResult = {
     one: 1,  // single-row result is expected;
     many: 2,  // multi-row result is expected;
     none: 4,  // no rows expected;
-    any: 6   // (default) = many|none = any result.
+    any: 6,   // (default) = many|none = any result.
+    passthru: 8 // return original pg result
 };
 
 ////////////////////////////////////////////////
@@ -192,8 +193,10 @@ function $query(db, query, values, qrm, options) {
             errMsg = "Parameter 'query' must be a text string.";
         } else {
             var badMask = queryResult.one | queryResult.many; // the combination isn't supported;
-            if ((qrm & badMask) === badMask || qrm < 1 || qrm > 6) {
+            if ((qrm & badMask) === badMask || qrm < 1 || qrm > 8) {
                 errMsg = "Invalid Query Result Mask specified.";
+            } if ((qrm & queryResult.passthru) && (qrm & queryResult.passthru) !== qrm) {
+                errMsg = "Invalid Query Result Mask specified - passthru must be used alone.";
             } else {
                 if (!pgFormatting) {
                     // use 'pg-promise' implementation of parameter formatting;
@@ -228,6 +231,8 @@ function $query(db, query, values, qrm, options) {
                     var data;
                     if (err) {
                         errMsg = err;
+                    } else if (qrm & queryResult.passthru) {
+                      data = result;
                     } else {
                         data = result.rows;
                         var l = result.rows.length;
@@ -325,6 +330,11 @@ function $extend(obj, cn, db, options) {
     // Expects any kind of return data (same as method 'manyOrNone');
     obj.any = function (query, values) {
         return obj.query(query, values, queryResult.many | queryResult.none);
+    };
+
+    // Returns raw result from the pg library
+    obj.passthru = function (query, values) {
+        return obj.query(query, values, queryResult.passthru);
     };
 
     // Query a function with specified Query Result Mask;

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,9 +193,9 @@ function $query(db, query, values, qrm, options) {
             errMsg = "Parameter 'query' must be a text string.";
         } else {
             var badMask = queryResult.one | queryResult.many; // the combination isn't supported;
-            if ((qrm & badMask) === badMask || qrm < 1 || qrm > 8) {
+            if ((qrm & badMask) === badMask || qrm < 1 || qrm > 8 || qrm === 7) {
                 errMsg = "Invalid Query Result Mask specified.";
-            } if ((qrm & queryResult.passthru) && (qrm & queryResult.passthru) !== qrm) {
+            } else if ((qrm & queryResult.passthru) && (qrm & queryResult.passthru) !== qrm) {
                 errMsg = "Invalid Query Result Mask specified - passthru must be used alone.";
             } else {
                 if (!pgFormatting) {

--- a/test/dbSpec.js
+++ b/test/dbSpec.js
@@ -427,9 +427,9 @@ describe("Queries must not allow invalid QRM (Query Request Mask) combinations",
             expect(error).toBe("Invalid Query Result Mask specified.");
         });
     });
-    it("method 'query' must throw an error when QRM is > 6", function () {
+    it("method 'query' must throw an error when QRM is > 8", function () {
         var result, error;
-        db.query("select * from person", undefined, 7)
+        db.query("select * from person", undefined, 9)
             .then(function (data) {
                 result = data;
             }, function (reason) {


### PR DESCRIPTION
Currently, there is no way to get original result from the pg library. That is needed mostly to get `rowCount` property, which pg-promise completely hides. Sometimes, one needs to know how many rows were modified during update/delete, without actually returning any data.

I've added backwards compatible query result called `passthru`. 

I would actually assume it would be default behavior for `query` method (I was very surprised it does not exist), but that would, indeed, be breaking change. One should use specific methods when they are needed. In my opinion, query should just convert pg call to promise.


