### PR TITLE
Removed 'Stream not initialized' check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -703,10 +703,6 @@ function $stream(ctx, qs, init) {
     } catch (err) {
         error = err;
     }
-    if (!error && !qs._reading) {
-        // the stream wasn't initialized by the callback function;
-        error = "Stream not initialized.";
-    }
     if (error) {
         stream._fetch = fetch;
         $notify.error(ctx.options, error, {

--- a/test/streamSpec.js
+++ b/test/streamSpec.js
@@ -88,23 +88,6 @@ describe("Method stream", function () {
                 }
             });
         });
-        describe("with empty initialization callback", function () {
-            var result;
-            beforeEach(function (done) {
-                var stream = {
-                    _reading: false,
-                    state: 'initialized'
-                };
-                db.stream(stream, dummy)
-                    .then(dummy, function (reason) {
-                        result = reason;
-                        done();
-                    })
-            });
-            it("must throw an error", function () {
-                expect(result).toBe("Stream not initialized.");
-            });
-        });
         describe("with initialization callback throwing error", function () {
             var result;
             beforeEach(function (done) {


### PR DESCRIPTION
Checking _reading is not correct, because
it will be set to true only if the stream
is in the flowing mode.  The stream consumer
may choose to use the stream in the paused mode,
and call the read() function to iterativelly
get each next result, in which case the check
will fail.