### PR TITLE
fallback when run from Node interpreter.

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -125,7 +125,7 @@ function isPathAbsolute(path) {
 }
 
 module.exports = {
-    startDir: $path.dirname(process.argv[1]),
+    startDir: $path.dirname(process.argv[1] || process.cwd()),
     isPathAbsolute: isPathAbsolute,
     lock: lock,
     isText: isText,


### PR DESCRIPTION
This bug was introduced with 9ea9385. Since Node interpreter don't have `process.argv[1]`, `path.dirname` would fail with the following error:

    TypeError: Path must be a string. Received undefined

See: #158.