### PR TITLE
Adds query error message for undefined query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -36,6 +36,7 @@ function $query(ctx, query, values, qrm, config) {
     }
 
     var error, isFunc,
+        isDefined = query !== undefined, 
         opt = ctx.options,
         pgFormatting = opt.pgFormatting,
         capSQL = opt.capSQL,
@@ -77,7 +78,11 @@ function $query(ctx, query, values, qrm, config) {
 
     if (!error) {
         if (!pgFormatting && !$npm.utils.isText(query)) {
-            error = new TypeError(isFunc ? "Invalid function name." : "Invalid query format.");
+            if (isDefined) {
+                errMsg = isFunc ? "Invalid function name." : "Invalid query format.";
+            }else {
+                errMsg = "Query not defined.";
+            }
         }
         if (query instanceof ExternalQuery) {
             var qp = query.parse();


### PR DESCRIPTION
When calling a db statement through a QueryFile, if the programmer misspells the QueryFile name, the resulting error is not descriptive. 
This commits provides one additional error message to take care of such case

An example of such problem is shown in the following demo: https://github.com/shesko/pg-promise-error-handling