### PR TITLE
make sure a constructor exists before attempting to check its name

### DIFF
--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -248,7 +248,7 @@ function $formatQuery(query, values, raw, options) {
             // $1, $2,... formatting to be applied;
             return formatAs.array(query, values, raw, options);
         }
-        if (!(values instanceof Date || values instanceof Buffer || values.constructor.name === 'QueryFile')) {
+        if (!(values instanceof Date || values instanceof Buffer || (values.constructor && values.constructor.name === 'QueryFile'))) {
             // $*propName* formatting to be applied;
             return formatAs.object(query, values, raw, options);
         }


### PR DESCRIPTION
this popped up on us because we use an object that's created similar to `Object.create(null)` as parameters with a QueryFile. since it has no constructor it was throwing an error `cannot read property 'name' of undefined`.