### PR TITLE
bluebird 3.x cancellation support for db.query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -121,7 +121,7 @@ function $query(ctx, query, values, qrm, config) {
         }
     }
 
-    return $p(function (resolve, reject) {
+    return $p(function (resolve, reject, onCancel) {
 
         if (notifyReject()) {
             return;
@@ -132,7 +132,7 @@ function $query(ctx, query, values, qrm, config) {
         }
         var start = Date.now();
         try {
-            ctx.db.client.query(query, params, function (err, result) {
+            var q = ctx.db.client.query(query, params, function (err, result) {
                 var data;
                 if (!err) {
                     $npm.utils.addReadProp(result, 'duration', Date.now() - start);
@@ -182,6 +182,14 @@ function $query(ctx, query, values, qrm, config) {
                     resolve(data);
                 }
             });
+            //  bluebird 3.x cancellation support
+            //  details: http://bluebirdjs.com/docs/api/cancellation.html#cancellation
+            if (onCancel && typeof onCancel === 'function') {
+                onCancel(function () {
+                    config.pgp.pg.cancel(ctx.cn, ctx.db.client, q);
+                    ctx.disconnect();
+                });
+            }
         } catch (e) {
             // this can only happen as a result of an internal failure within node-postgres,
             // like during a sudden loss of communications, which is impossible to reproduce


### PR DESCRIPTION
Hi,

I added a basic cancellation support for db.query.

I'm sure there are other use cases, here is mine:
1. There are valid user-parameterised queries, that can take longer (5 - 10 minutes)
2. But usually the user would rather abort the query and specify a narrower filter
3. Small servers, even a few abandoned long running query can have noticeable effects on performance (not to mention possible locks, etc.)

_Building rest api around the concept of cancellable requests will be the next challenge, but first I had to make sure, that the queries can be canceled._ 

This cannot be done without some support from this library (eg. exposing the query and the client variables somehow, and I couldn't figure out a way to do that).

The PR **only works with** promise implementations compatible with **bluebird 3.x cancellation syntax** (http://bluebirdjs.com/docs/api/cancellation.html#cancellation), and could possibly break with some other hypothetical promise implementation, that uses a 3rd callback for something else.

The bluebird implementation does not call success or failure callbacks after cancel, only finally.
The node-postgres cancel implementation seems to be correct for this case.

An alternative could be a 'cancel-is-error' implementation, in which case the failure callbacks should be called on cancellation. That would require a different API, and some workaround for node-postgres too, because it doesn't emit an error, when a queued query is canceled. (BTW the latter is not a problem, I have a working solution for that.)

This is a first draft, I haven't extensively tested it yet.
