### PR TITLE
Cancel with emitter arg

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -230,12 +230,12 @@ function Database(cn, dc, config) {
      * When the query result is an array, it is extended with a hidden property `duration`
      * - query duration in milliseconds.
      */
-    this.query = function (query, values, qrm) {
+    this.query = function (query, values, qrm, onCancel) {
         var self = this, ctx = createContext();
         return config.$npm.connect.pool(ctx)
             .then(function (db) {
                 ctx.connect(db);
-                return config.$npm.query.call(self, ctx, query, values, qrm);
+                return config.$npm.query.call(self, ctx, query, values, qrm, onCancel);
             })
             .then(function (data) {
                 ctx.disconnect();

--- a/lib/query.js
+++ b/lib/query.js
@@ -22,9 +22,22 @@ var QueryResultError = $npm.errors.QueryResultError,
 
 var badMask = $npm.result.one | $npm.result.many; // the combination isn't supported;
 
+function cancelQuery(pg, cn, client, query) {
+    if ((client.activeQuery || client._activeQuery) === query) {
+        pg.cancel(cn, client, query);
+    } else {
+        var queryQueue = client.queryQueue || client._queryQueue;
+        var i = queryQueue.indexOf(query);
+        if (i > -1) {
+            queryQueue.splice(i, 1);
+            return true;
+        }
+    }
+}
+
 //////////////////////////////
 // Generic query method;
-function $query(ctx, query, values, qrm, config) {
+function $query(ctx, query, values, qrm, config, onCancel) {
 
     var isResult, $p = config.promise;
 
@@ -132,7 +145,8 @@ function $query(ctx, query, values, qrm, config) {
         }
         var start = Date.now();
         try {
-            ctx.db.client.query(query, params, function (err, result) {
+            var q = ctx.db.client.query(query, params, function (err, result) {
+                if (typeof onCancel === 'function') { onCancel(); }
                 var data;
                 if (!err) {
                     $npm.utils.addReadProp(result, 'duration', Date.now() - start);
@@ -182,6 +196,15 @@ function $query(ctx, query, values, qrm, config) {
                     resolve(data);
                 }
             });
+
+            if (typeof onCancel === 'function') {
+                onCancel(function () {
+                    if (cancelQuery(config.pgp.pg, ctx.cn, ctx.client.db, q)) {
+                        error = new Error('Custom cancel error message...?');
+                        notifyReject();
+                    }
+                });
+            }
         } catch (e) {
             // this can only happen as a result of an internal failure within node-postgres,
             // like during a sudden loss of communications, which is impossible to reproduce
@@ -223,7 +246,7 @@ function $query(ctx, query, values, qrm, config) {
 }
 
 module.exports = function (config) {
-    return function (ctx, query, values, qrm) {
-        return $query.call(this, ctx, query, values, qrm, config);
+    return function (ctx, query, values, qrm, onCancel) {
+        return $query.call(this, ctx, query, values, qrm, config, onCancel);
     };
 };

--- a/lib/utils/public.js
+++ b/lib/utils/public.js
@@ -498,6 +498,20 @@ function buildSqlModule(config) {
     return code;
 }
 
+function createCancelEmitter() {
+    function onCancel(cb) {
+        onCancel._cb = cb;
+    }
+
+    onCancel.cancel = function () {
+        if (onCancel._cb) {
+            onCancel._cb();
+            delete onCancel._cb;
+        }
+    };
+    return onCancel;
+}
+
 
 /**
  * @namespace utils
@@ -532,7 +546,8 @@ module.exports = {
     camelizeVar: camelizeVar,
     enumSql: enumSql,
     objectToCode: objectToCode,
-    buildSqlModule: buildSqlModule
+    buildSqlModule: buildSqlModule,
+    createCancelEmitter: createCancelEmitter
 };
 
 Object.freeze(module.exports);

--- a/test/dbSpec.js
+++ b/test/dbSpec.js
@@ -930,6 +930,47 @@ describe("Executing method query", function () {
 
 });
 
+describe("Cancellation", function () {
+    it("cancelled query must in an error", function () {
+        var result1, result2, result3;
+
+        var cancel1 = pgp.utils.createCancelEmitter();
+        // var cancel2 = pgp.utils.createCancelEmitter();
+
+        db.query('SELECT pg_sleep(1)', undefined, undefined, cancel1).then(function () {
+            result1 = 'success';
+        }).catch(function (e) {
+            result1 = 'error';
+        });
+
+        db.query('SELECT pg_sleep(1)').then(function () {
+            result2 = 'success';
+        }).catch(function (e) {
+            result2 = 'error';
+        });
+
+        db.query('SELECT pg_sleep(1)').then(function () {
+            result3 = 'success';
+        }).catch(function (e) {
+            result3 = 'error';
+        });
+
+        setTimeout(function () {
+            cancel1.cancel();
+        }, 800);
+
+        waitsFor(function () {
+            return result1 && result2 && result3;
+        }, "Query timed out", 5000);
+
+        runs(function () {
+            expect(result1).toEqual('error');
+            expect(result2).toEqual('success');
+            expect(result3).toEqual('success')
+        });
+    });
+});
+
 describe("Transactions", function () {
 
     // NOTE: The same test for 100,000 inserts works also the same.


### PR DESCRIPTION
Alternative to https://github.com/vitaly-t/pg-promise/pull/225.

This is PR is not for merge, just a proof of concept, to show that cancellation is possible (but cumbersome) without the promise library supporting it.
If you would like, I could put together complete patch for each query function, or we could shelf the issue until someone comes up with a better solution.
