### PR TITLE
typescript 2 support - @types

### DIFF
--- a/typescript/@types/pg-minify/index.d.ts
+++ b/typescript/@types/pg-minify/index.d.ts
@@ -1,0 +1,36 @@
+//////////////////////////////////////////////////////////
+// Module pg-minify that's used and exposed by pg-promise
+//
+// Supported version of pg-minify: 0.2.4 and later.
+//
+// pg-minify: https://github.com/vitaly-t/pg-minify
+//////////////////////////////////////////////////////////
+declare module 'pg-minify' {
+
+    interface IErrorPosition {
+        line: number,
+        column: number
+    }
+
+    namespace pgMinify {
+        enum parsingErrorCode {
+            unclosedMLC = 1,    // Unclosed multi-line comment.
+            unclosedText = 2,   // Unclosed text block.
+            unclosedQI = 3,     // Unclosed quoted identifier.
+            multiLineQI = 4     // Multi-line quoted identifiers are not supported.
+        }
+
+        class SQLParsingError implements Error {
+            name: string;
+            message: string;
+            stack: string;
+            error: string;
+            code: parsingErrorCode;
+            position: IErrorPosition;
+        }
+    }
+
+    function pgMinify(sql: string, options?: { compress?: boolean }): string;
+
+    export = pgMinify;
+}

--- a/typescript/@types/pg-promise-extlib/index.d.ts
+++ b/typescript/@types/pg-promise-extlib/index.d.ts
@@ -1,0 +1,206 @@
+//////////////////////////////////////////////////////////////////////////////
+// This definition file should support the external libraries that don't have
+// a Typescript definition file yet or to provide a custom / subset version,
+// i.e. pg-subset.
+//////////////////////////////////////////////////////////////////////////////
+
+
+//////////////////////////////////////////////////////////////////////////////
+// *** pg-subset ***
+//////////////////////////////////////////////////////////////////////////////
+// Declaring only a subset of the 'pg' module that's useful within pg-promise.
+//
+// Calling it 'pg-subset' to avoid a conflict in case the application also
+// includes the official 'pg' typings.
+//
+// Supported version of pg: 4.3.0 and later.
+//
+// pg: https://github.com/brianc/node-postgres
+//////////////////////////////////////////////////////////////////////////////
+declare module 'pg-subset' {
+
+    import { EventEmitter } from 'events';
+    import { Buffer } from 'buffer';
+
+    namespace pg {
+
+        interface IColumn {
+            name: string,
+            dataTypeID: number,
+
+            // properties below are not available within Native Bindings:
+
+            tableID: number,
+            columnID: number,
+            dataTypeSize: number,
+            dataTypeModifier: number,
+            format: string
+        }
+
+        interface IResult {
+            command: string,
+            rowCount: number,
+            rows: Array<any>,
+            fields: Array<IColumn>,
+
+            duration: number, // pg-promise extension
+
+            // properties below are not available within Native Bindings:
+
+            rowAsArray: boolean
+        }
+
+        // SSL configuration;
+        // For property types and documentation see:
+        // http://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+        interface ISSLConfig {
+            ca?: string | string[] | Buffer | Buffer[];
+            pfx?: string | Buffer;
+            cert?: string | string[] | Buffer | Buffer[];
+            key?: string | string[] | Buffer | Object[];
+            passphrase?: string;
+            rejectUnauthorized?: boolean;
+            NPNProtocols?: string[] | Buffer;
+        }
+
+        interface IConnectionParameters {
+            database?: string;
+            user?: string;
+            password?: string;
+            port?: number;
+            host?: string;
+            ssl?: boolean | ISSLConfig;
+            binary?: boolean;
+            client_encoding?: string;
+            application_name?: string;
+            fallback_application_name?: string;
+            isDomainSocket?: boolean;
+        }
+
+        // Interface of 'pg-types' module;
+        // See: https://github.com/brianc/node-pg-types
+        interface ITypes {
+            setTypeParser: (oid: number, format: string | ((value: string) => any)) => void;
+            getTypeParser: (oid: number, format?: string) => any;
+            arrayParser: (source: string, transform: (entry: any) => any) => Array<any>;
+        }
+
+        interface IDefaults {
+            // database host. defaults to localhost
+            host: string,
+
+            //database user's name
+            user: string,
+
+            //name of database to connect
+            database: string,
+
+            //database user's password
+            password?: string,
+
+            //database port
+            port: number,
+
+            //number of rows to return at a time from a prepared statement's
+            //portal. 0 will return all rows at once
+            rows: number,
+
+            // binary result mode
+            binary: boolean,
+
+            //Connection pool options - see https://github.com/coopernurse/node-pool
+            //number of connections to use in connection pool
+            //0 will disable connection pooling
+            poolSize: number,
+
+            //max milliseconds a client can go unused before it is removed
+            //from the pool and destroyed
+            poolIdleTimeout: number,
+
+            //frequency to check for idle clients within the client pool
+            reapIntervalMillis: number,
+
+            //pool log function / boolean
+            poolLog: boolean,
+
+            client_encoding: string,
+
+            ssl: boolean | ISSLConfig,
+
+            application_name?: string,
+
+            fallback_application_name?: string,
+
+            parseInputDatesAsUTC: boolean
+        }
+
+        class Connection {
+            // not needed within pg-promise;
+        }
+
+        class Query {
+            // not needed within pg-promise;
+        }
+
+        class Client extends EventEmitter {
+            constructor(cn: string | IConnectionParameters);
+
+            query: (config: any, values: any, callback: (err: Error, result: IResult) => void) => Query;
+
+            on(event: 'drain', listener: () => void): this;
+            on(event: 'error', listener: (err: Error) => void): this;
+            on(event: 'notification', listener: (message: any) => void): this;
+            on(event: 'notice', listener: (message: any) => void): this;
+            on(event: string, listener: Function): this;
+
+            connectionParameters: IConnectionParameters;
+            database: string;
+            user: string;
+            password: string;
+            port: number;
+            host: string;
+
+            // properties below are not available within Native Bindings:
+
+            queryQueue: Array<Query>;
+            binary: boolean;
+            ssl: boolean | ISSLConfig;
+            secretKey: number;
+            processID: number;
+            encoding: string;
+            readyForQuery: boolean;
+            activeQuery: Query;
+        }
+
+        var defaults: IDefaults;
+        var types: ITypes;
+    }
+
+    export = pg;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// *** ext-promise ***
+//////////////////////////////////////////////////////////////////////////////
+//  External Promise Provider.
+//  The purpose of this module is to make it possible to enable declarations of a custom promise library
+//  by patching this file manually. It presumes that you are already initializing pg-promise with a custom
+//  promise library, using option `promiseLib`. If not, then you cannot use the provisions documented here.
+//  Example of enabling declarations for Bluebird:
+//  1. Install Bluebird ambient TypeScript as you normally would:
+//  $ typings install bluebird --ambient --save
+//  2. Add the reference path here, similar to this:
+//  /// <reference path='../../../typings/main' />
+//  3. Replace line `export=Promise` with the following:
+//  import * as promise from 'bluebird';
+//  export=promise;
+//  Unfortunately, as of today it is impossible to use custom promises as TypeScript generics,
+//  and this is why we have this file here, so it can be manually patched.
+//  You can find research details on this matter from the following link:
+//  http://stackoverflow.com/questions/36593087/using-a-custom-promise-as-a-generic-type
+//  In the meantime, if you do not want to get these settings overridden during an update or deployment,
+//  it may be a good idea to copy all of the *.ts files into your own project, and use them from there.
+//////////////////////////////////////////////////////////////////////////////
+declare module 'ext-promise' {
+    export = Promise; // Using ES6 Promise by default
+}

--- a/typescript/@types/pg-promise/index.d.ts
+++ b/typescript/@types/pg-promise/index.d.ts
@@ -1,4 +1,5 @@
 declare module 'pg-promise' {
+    import 'pg-promise-extlib';
     import * as spexLib from 'spex';
     import * as pg from 'pg-subset';
     import * as XPromise from 'ext-promise';

--- a/typescript/@types/pg-promise/index.d.ts
+++ b/typescript/@types/pg-promise/index.d.ts
@@ -1,0 +1,620 @@
+declare module 'pg-promise' {
+    import * as spexLib from 'spex';
+    import * as pg from 'pg-subset';
+    import * as XPromise from 'ext-promise';
+    import * as pgMinify from 'pg-minify';
+
+    type TQueryFileOptions = {
+        debug?: boolean,
+        minify?: boolean | 'after',
+        compress?: boolean,
+        params?: any
+    };
+
+    type TFormattingOptions = {
+        partial?: boolean,
+        default?: any
+    };
+
+    type TConnectionOptions = {
+        direct?: boolean;
+    };
+
+    type TPreparedBasic = {
+        name: string,
+        text: string,
+        values: Array<any>,
+        binary: boolean,
+        rowMode: string,
+        rows: number
+    };
+
+    type TParameterizedBasic = {
+        text: string,
+        values: Array<any>,
+        binary: boolean,
+        rowMode: string
+    };
+
+    type TPrepared = {
+        name: string,
+        text: string | pgPromise.QueryFile,
+        values?: Array<any>,
+        binary?: boolean,
+        rowMode?: string,
+        rows?: number
+    };
+
+    type TParameterized = {
+        text: string | pgPromise.QueryFile,
+        values?: Array<any>,
+        binary?: boolean,
+        rowMode?: string
+    };
+
+    type TQuery = string | pgPromise.QueryFile | TPrepared | TParameterized | pgPromise.PreparedStatement | pgPromise.ParameterizedQuery;
+
+    type TColumnConfig = {
+        name: string,
+        prop?: string,
+        mod?: string,
+        cast?: string,
+        cnd?: boolean,
+        def?: any,
+        init?: (value: any) => any,
+        skip?: (name: string) => boolean;
+    };
+
+    type TColumnSetOptions = {
+        table?: string | TTable | TableName,
+        inherit?: boolean
+    };
+
+    type TUpdateOptions = {
+        tableAlias?: string,
+        valueAlias?: string
+    };
+
+    type TTable = {
+        table: string,
+        schema?: string
+    };
+
+    type TQueryColumns = Column | ColumnSet | Array<string | TColumnConfig | Column>;
+
+    type TSqlBuildConfig = {
+        dir: string,
+        recursive?: boolean,
+        ignoreErrors?: boolean,
+        output?: string,
+        module?: {
+            path?: string,
+            name?: string
+        }
+    };
+
+    type QueryFormat = {
+        query: string | pgPromise.QueryFile,
+        values?: any,
+        options?: TFormattingOptions
+    };
+
+    // Query formatting namespace;
+    // API: http://vitaly-t.github.io/pg-promise/formatting.html
+    interface IFormatting {
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.array
+        array(arr: Array<any> | (() => Array<any>)): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.bool
+        bool(value: any | (() => any)): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.buffer
+        buffer(obj: Object | (() => Object), raw?: boolean): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.csv
+        csv(values: any | (() => any)): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.date
+        date(d: Date | (() => Date), raw?: boolean): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.format
+        format(query: string | pgPromise.QueryFile, values?: any, options?: TFormattingOptions): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.func
+        func(func: () => any, raw?: boolean, obj?: Object): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.json
+        json(obj: any | (() => any), raw?: boolean): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.name
+        name(name: any): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.number
+        number(value: number | (() => number)): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.text
+        text(value: any | (() => any), raw?: boolean): string;
+
+        // API: http://vitaly-t.github.io/pg-promise/formatting.html#.value
+        value(value: any | (() => any)): string;
+    }
+
+    // Event context extension for tasks + transactions;
+    // See: http://vitaly-t.github.io/pg-promise/Task.html#.ctx
+    interface ITaskContext {
+
+        // these are set in the beginning of each task/transaction:
+        context: any;
+        isFresh: boolean;
+        isTX: boolean;
+        start: Date;
+        tag: any;
+        dc: any;
+
+        // these are set at the end of each task/transaction:
+        finish: Date;
+        success: boolean;
+        result: any;
+    }
+
+    // Generic Event Context interface;
+    // See: http://vitaly-t.github.io/pg-promise/global.html#event:query
+    interface IEventContext {
+        client: pg.Client;
+        cn: any;
+        dc: any;
+        query: any;
+        params: any;
+        ctx: ITaskContext;
+    }
+
+    // Transaction Isolation Level;
+    // API: http://vitaly-t.github.io/pg-promise/global.html#isolationLevel
+    enum isolationLevel {
+        none = 0,
+        serializable = 1,
+        repeatableRead = 2,
+        readCommitted = 3
+    }
+
+    // TransactionMode class;
+    // API: http://vitaly-t.github.io/pg-promise/TransactionMode.html
+    class TransactionMode {
+        constructor(tiLevel?: isolationLevel, readOnly?: boolean, deferrable?: boolean);
+        constructor(options: { tiLevel?: isolationLevel, readOnly?: boolean, deferrable?: boolean });
+    }
+
+    // QueryResultError interface;
+    // API: http://vitaly-t.github.io/pg-promise/QueryResultError.html
+    interface IQueryResultError extends Error {
+
+        // standard error properties:
+        name: string;
+        message: string;
+        stack: string;
+
+        // extended properties:
+        result: pg.IResult;
+        received: number;
+        code: queryResultErrorCode;
+        query: string;
+        values: any;
+
+        // API: http://vitaly-t.github.io/pg-promise/QueryResultError.html#.toString
+        toString(): string;
+    }
+
+    // QueryFileError interface;
+    // API: http://vitaly-t.github.io/pg-promise/QueryFileError.html
+    interface IQueryFileError extends Error {
+
+        // standard error properties:
+        name: string;
+        message: string;
+        stack: string;
+
+        // extended properties:
+        file: string;
+        options: TQueryFileOptions;
+        error: pgMinify.SQLParsingError;
+
+        // API: http://vitaly-t.github.io/pg-promise/QueryFileError.html#.toString
+        toString(): string;
+    }
+
+    // PreparedStatementError interface;
+    // API: http://vitaly-t.github.io/pg-promise/PreparedStatementError.html
+    interface IPreparedStatementError extends Error {
+
+        // standard error properties:
+        name: string;
+        message: string;
+        stack: string;
+
+        // extended properties:
+        error: IQueryFileError;
+
+        // API: http://vitaly-t.github.io/pg-promise/PreparedStatementError.html#.toString
+        toString(): string;
+    }
+
+    // ParameterizedQueryError interface;
+    // API: http://vitaly-t.github.io/pg-promise/ParameterizedQueryError.html
+    interface IParameterizedQueryError extends Error {
+
+        // standard error properties:
+        name: string;
+        message: string;
+        stack: string;
+
+        // extended properties:
+        error: IQueryFileError;
+
+        // API: http://vitaly-t.github.io/pg-promise/ParameterizedQueryError.html#.toString
+        toString(): string;
+    }
+
+    // Query Result Error Code;
+    // API: http://vitaly-t.github.io/pg-promise/global.html#queryResultErrorCode
+    enum queryResultErrorCode {
+        noData = 0,
+        notEmpty = 1,
+        multiple = 2
+    }
+
+    // Errors namespace
+    // API: http://vitaly-t.github.io/pg-promise/errors.html
+    interface IErrors {
+        QueryResultError: IQueryResultError;
+        queryResultErrorCode: typeof queryResultErrorCode;
+        QueryFileError: IQueryFileError;
+        PreparedStatementError: IPreparedStatementError;
+        ParameterizedQueryError: IParameterizedQueryError;
+    }
+
+    // Transaction Mode namespace;
+    // API: http://vitaly-t.github.io/pg-promise/txMode.html
+    interface ITXMode {
+        isolationLevel: typeof isolationLevel;
+        TransactionMode: typeof TransactionMode;
+    }
+
+    // General-purpose functions
+    // API: http://vitaly-t.github.io/pg-promise/utils.html
+    interface IUtils {
+        camelize(text: string): string;
+        camelizeVar(text: string): string;
+        objectToCode(obj: any, cb?: (value: any, name: string, obj: any) => any): string;
+        enumSql(dir: string, options?: { recursive?: boolean, ignoreErrors?: boolean }, cb?: (file: string, name: string, path: string) => any): any;
+        buildSqlModule(config?: string | TSqlBuildConfig): string;
+    }
+
+    // helpers.TableName class;
+    // API: http://vitaly-t.github.io/pg-promise/helpers.TableName.html
+    class TableName {
+        constructor(table: string, schema?: string);
+        constructor(table: TTable);
+
+        // these are all read-only:
+        name: string;
+        table: string;
+        schema: string;
+
+        // API: http://vitaly-t.github.io/pg-promise/helpers.TableName.html#.toString
+        toString(): string;
+    }
+
+    // helpers.Column class;
+    // API: http://vitaly-t.github.io/pg-promise/helpers.Column.html
+    class Column {
+        constructor(col: string | TColumnConfig);
+
+        // these are all read-only:
+        name: string;
+        prop: string;
+        mod: string;
+        cast: string;
+        cnd: boolean;
+        def: any;
+
+        init: (value: any) => any;
+        skip: (name: string) => boolean;
+
+        // API: http://vitaly-t.github.io/pg-promise/helpers.Column.html#.toString
+        toString(): string;
+    }
+
+    // helpers.Column class;
+    // API: http://vitaly-t.github.io/pg-promise/helpers.ColumnSet.html
+    class ColumnSet {
+        constructor(columns: Column, options?: TColumnSetOptions);
+        constructor(columns: Array<string | TColumnConfig | Column>, options?: TColumnSetOptions);
+        constructor(columns: Object, options?: TColumnSetOptions);
+
+        // these are all read-only:
+        columns: Array<Column>;
+        table: TableName;
+
+        canUpdate(data: Object | Array<Object>): boolean;
+
+        extend(columns: Column | ColumnSet | Array<string | TColumnConfig | Column>): ColumnSet;
+
+        merge(columns: Column | ColumnSet | Array<string | TColumnConfig | Column>): ColumnSet;
+
+        // API: http://vitaly-t.github.io/pg-promise/helpers.ColumnSet.html#.toString
+        toString(): string;
+    }
+
+    // Query Formatting Helpers
+    // API: http://vitaly-t.github.io/pg-promise/helpers.html
+    interface IHelpers {
+
+        concat(queries: Array<string | QueryFormat | pgPromise.QueryFile>): string;
+
+        insert(data: Object | Array<Object>, columns?: TQueryColumns, table?: string | TTable | TableName): string;
+        update(data: Object | Array<Object>, columns?: TQueryColumns, table?: string | TTable | TableName, options?: TUpdateOptions): string;
+
+        values(data: Object | Array<Object>, columns?: TQueryColumns): string;
+        sets(data: Object, columns?: TQueryColumns): string;
+
+        Column: typeof Column;
+        ColumnSet: typeof ColumnSet;
+        TableName: typeof TableName;
+    }
+
+    interface IGenericPromise {
+        (cb: (resolve: (value?: any) => void, reject: (value?: any) => void) => void): XPromise<any>;
+        resolve(value?: any): void;
+        reject(value?: any): void;
+    }
+
+    // API: http://vitaly-t.github.io/pg-promise/Database.html#$config
+    interface ILibConfig<Ext> {
+        version: string;
+        promiseLib: any;
+        promise: IGenericPromise;
+        options: IOptions<Ext>;
+        pgp: pgPromise.IMain;
+        $npm: any;
+    }
+
+    // Empty Extensions
+    interface IEmptyExt {
+
+    }
+
+    // Main protocol of the library;
+    // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
+    namespace pgPromise {
+        var minify: typeof pgMinify;
+
+        // Query Result Mask;
+        // API: http://vitaly-t.github.io/pg-promise/global.html#queryResult
+        enum queryResult {
+            one = 1,
+            many = 2,
+            none = 4,
+            any = 6
+        }
+
+        // PreparedStatement class;
+        // API: http://vitaly-t.github.io/pg-promise/PreparedStatement.html
+        class PreparedStatement {
+
+            // API: http://vitaly-t.github.io/pg-promise/PreparedStatement.html
+            constructor(name: string, text: string | QueryFile, values?: Array<any>);
+            constructor(obj: PreparedStatement);
+            constructor(obj: TPrepared);
+
+            // standard properties:
+            name: string;
+            text: string | QueryFile;
+            values: Array<any>;
+
+            // advanced properties:
+            binary: boolean;
+            rowMode: string;
+            rows: any;
+
+            // API: http://vitaly-t.github.io/pg-promise/PreparedStatement.html#.parse
+            parse(): TPreparedBasic | IPreparedStatementError;
+
+            // API: http://vitaly-t.github.io/pg-promise/PreparedStatement.html#.toString
+            toString(): string;
+        }
+
+        // ParameterizedQuery class;
+        // API: http://vitaly-t.github.io/pg-promise/ParameterizedQuery.html
+        class ParameterizedQuery {
+
+            // API: http://vitaly-t.github.io/pg-promise/ParameterizedQuery.html
+            constructor(text: string | QueryFile, values?: Array<any>);
+            constructor(obj: ParameterizedQuery);
+            constructor(obj: TParameterized);
+
+            // standard properties:
+            text: string | QueryFile;
+            values: Array<any>;
+
+            // advanced properties:
+            binary: boolean;
+            rowMode: string;
+
+            // API: http://vitaly-t.github.io/pg-promise/ParameterizedQuery.html#.parse
+            parse(): TParameterizedBasic | IParameterizedQueryError;
+
+            // API: http://vitaly-t.github.io/pg-promise/ParameterizedQuery.html#.toString
+            toString(): string;
+        }
+
+        // QueryFile class;
+        // API: http://vitaly-t.github.io/pg-promise/QueryFile.html
+        class QueryFile {
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html
+            constructor(file: string, options?: TQueryFileOptions);
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#error
+            error: Error;
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#file
+            file: string;
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#options
+            options: any;
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#query
+            query: string;
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#.prepare
+            prepare(): void;
+
+            // API: http://vitaly-t.github.io/pg-promise/QueryFile.html#.toString
+            toString(): string;
+        }
+
+        // PromiseAdapter class;
+        // API: http://vitaly-t.github.io/pg-promise/PromiseAdapter.html
+        class PromiseAdapter {
+            constructor(create: (cb: any) => Object, resolve: (data: any) => void, reject: (reason: any) => void);
+        }
+
+        var txMode: ITXMode;
+        var errors: IErrors;
+        var utils: IUtils;
+        var as: IFormatting;
+
+        // Database full protocol;
+        // API: http://vitaly-t.github.io/pg-promise/Database.html
+        //
+        // We export this interface only to be able to help IntelliSense cast extension types correctly,
+        // which doesn't always work, depending on the version of IntelliSense being used.
+        interface IDatabase<Ext> extends IBaseProtocol<Ext> {
+            connect(options?: TConnectionOptions): XPromise<IConnected<Ext>>;
+
+            // A hidden property, for integrating with third-party libraries.
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#$config
+            $config: ILibConfig<Ext>;
+        }
+
+        type IConfig = pg.IConnectionParameters;
+
+        // Post-initialization interface;
+        // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
+        interface IMain {
+            (cn: string | IConfig, dc?: any): pgPromise.IDatabase<IEmptyExt>;
+            <T>(cn: string | IConfig, dc?: any): pgPromise.IDatabase<T> & T;
+            PromiseAdapter: typeof pgPromise.PromiseAdapter;
+            PreparedStatement: typeof pgPromise.PreparedStatement;
+            ParameterizedQuery: typeof pgPromise.ParameterizedQuery;
+            QueryFile: typeof pgPromise.QueryFile;
+            queryResult: typeof pgPromise.queryResult;
+            minify: typeof pgMinify;
+            spex: spexLib.ISpex;
+            errors: IErrors;
+            utils: IUtils;
+            txMode: ITXMode;
+            helpers: IHelpers;
+            as: IFormatting;
+            end(): void;
+            pg: typeof pg;
+        }
+
+        // Additional methods available inside tasks + transactions;
+        // API: http://vitaly-t.github.io/pg-promise/Task.html
+        interface ITask<Ext> extends IBaseProtocol<Ext>, spexLib.ISpexBase {
+            // API: http://vitaly-t.github.io/pg-promise/Task.html#.ctx
+            ctx: ITaskContext;
+        }
+
+        // Base database protocol
+        // API: http://vitaly-t.github.io/pg-promise/Database.html
+        interface IBaseProtocol<Ext> {
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.query
+            query(query: TQuery, values?: any, qrm?: pgPromise.queryResult): XPromise<any>;
+
+            // result-specific methods;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.none
+            none(query: TQuery, values?: any): XPromise<void>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.one
+            one(query: TQuery, values?: any, cb?: (value: any) => any, thisArg?: any): XPromise<any>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.oneOrNone
+            oneOrNone(query: TQuery, values?: any, cb?: (value: any) => any, thisArg?: any): XPromise<any>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.many
+            many(query: TQuery, values?: any): XPromise<Array<any>>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.manyOrNone
+            manyOrNone(query: TQuery, values?: any): XPromise<Array<any>>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.any
+            any(query: TQuery, values?: any): XPromise<Array<any>>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.result
+            result(query: TQuery, values?: any, cb?: (value: any) => any, thisArg?: any): XPromise<pg.IResult>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.stream
+            stream(qs: Object, init: (stream: NodeJS.ReadableStream) => void): XPromise<{ processed: number, duration: number }>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.func
+            func(funcName: string, values?: any, qrm?: pgPromise.queryResult): XPromise<any>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.proc
+            proc(procName: string, values?: any, cb?: (value: any) => any, thisArg?: any): XPromise<any>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.map
+            map(query: TQuery, values: any, cb: (row: any, index: number, data: Array<any>) => any, thisArg?: any): XPromise<Array<any>>;
+
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.each
+            each(query: TQuery, values: any, cb: (row: any, index: number, data: Array<any>) => void, thisArg?: any): XPromise<Array<any>>;
+
+            // Tasks
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.task
+            task(cb: (t: ITask<Ext> & Ext) => any): XPromise<any>;
+            task(tag: any, cb: (t: ITask<Ext> & Ext) => any): XPromise<any>;
+
+            // Transactions
+            // API: http://vitaly-t.github.io/pg-promise/Database.html#.tx
+            tx(cb: (t: ITask<Ext> & Ext) => any): XPromise<any>;
+            tx(tag: any, cb: (t: ITask<Ext> & Ext) => any): XPromise<any>;
+        }
+
+        // Database object in connected state;
+        interface IConnected<Ext> extends IBaseProtocol<Ext> {
+            client: pg.Client;
+            done(): void;
+        }
+
+    }
+
+    // Library's Initialization Options
+    // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
+    interface IOptions<Ext> {
+        noWarnings?: boolean;
+        pgFormatting?: boolean;
+        pgNative?: boolean,
+        promiseLib?: any;
+        connect?: (client: pg.Client, dc: any, fresh: boolean) => void;
+        disconnect?: (client: pg.Client, dc: any) => void;
+        query?: (e: IEventContext) => void;
+        receive?: (data: Array<any>, result: pg.IResult, e: IEventContext) => void;
+        task?: (e: IEventContext) => void;
+        transact?: (e: IEventContext) => void;
+        error?: (err: any, e: IEventContext) => void;
+        extend?: (obj: pgPromise.IDatabase<Ext> & Ext, dc: any) => void;
+        noLocking?: boolean;
+        capSQL?: boolean;
+    }
+
+    // Default library interface (before initialization)
+    // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
+    function pgPromise(options?: IOptions<IEmptyExt>): pgPromise.IMain;
+    function pgPromise<Ext>(options?: IOptions<Ext>): pgPromise.IMain;
+
+    export = pgPromise;
+}


### PR DESCRIPTION
Hi Vitaly,

I modified the structure of the Typescript definitions files and it didn't require too many modifications. I've been testing in our projects and it's working perfectly.

For using it, it's necessary to update to the 2nd version of typescript (global and local), update the tsconfig.json, to include the typeRoots value and also remove the previous typings setups - if the project is using it. Ex:

```
{
   "compilerOptions": {
        "module": "commonjs",
        "target": "es6",
        "rootDir": ".",
        "sourceMap": true,
        "emitDecoratorMetadata": true,
        "experimentalDecorators": true,
        "removeComments": false,
        "noImplicitAny": false,
        "moduleResolution": "node",
        "typeRoots": [
            "node_modules/@types/"
        ]
    }
}
```

After this, copy the definitions files folders from pg-promise to the @types folder, inside of node_modules -- as it isn't at the [@types repo](https://www.npmjs.com/~types) yet. You also must copy the spex and pg-monitor (if used by the project) - I just did a pull request for both also. Install the rest of definitions files from @types and it's done.

I didn't update the documentation, as I would like to see if you accept this pull request.

If it's okay, could you upload at the typescript ~types repo? Then we could install using 
`npm i @types/pg-promise`

Thanks! 
