### PR TITLE
[Doc] Prevent scroll bar to override text

### DIFF
--- a/jsdoc/style.css
+++ b/jsdoc/style.css
@@ -21,6 +21,7 @@ h4.name {
 
 section {
     border-bottom: none;
+    padding-left: 40px;
 }
 
 div#main {


### PR DESCRIPTION
Hello

When I scroll the doc I had this quite annoying scrollbar overriding text (under last Chrome) : 
![capture d ecran 2017-02-10 a 18 49 52](https://cloud.githubusercontent.com/assets/8417720/22838614/44da06d2-efc6-11e6-95ce-7c4b815ad6eb.png)

Here is a PR to add a padding to avoid this : 
![capture d ecran 2017-02-10 a 18 50 22](https://cloud.githubusercontent.com/assets/8417720/22838624/51726092-efc6-11e6-9a73-382983db21be.png)

Thanks @vitaly-t for pg-promise.
