### PR TITLE
Use `hasOwnProperty` from Object prototype

### DIFF
--- a/lib/helpers/columnSet.js
+++ b/lib/helpers/columnSet.js
@@ -214,7 +214,7 @@ function ColumnSet(columns, options) {
         } else {
             this.columns = [];
             for (var name in columns) {
-                if (inherit || columns.hasOwnProperty(name)) {
+                if (inherit || Object.prototype.hasOwnProperty.call(columns, name)) {
                     this.columns.push(new $npm.Column(name));
                 }
             }


### PR DESCRIPTION
This avoids the problem of `hasOwnProperty` and others not being defined when Object was created with `Object.create(null)`.