### PR TITLE
pass defaults to pg

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,6 +42,11 @@ var $npm = {
  *
  * This is a static property (can only be set prior to initialization).
  *
+ * @param {object} [options.defaults={}]
+ * Set PG driver-level default options such as parseInputDatesAsUTC or poolIdleTimeout.
+ *
+ * This property can only be set prior to initialization.
+ *
  * @param {object|function} [options.promiseLib=Promise]
  * Overrides the default promise library.
  *
@@ -132,7 +137,7 @@ function $main(options) {
 
         // list of supported initialization options:
         var validOptions = ['pgFormatting', 'pgNative', 'promiseLib', 'noLocking', 'capSQL', 'noWarnings',
-            'connect', 'disconnect', 'query', 'receive', 'task', 'transact', 'error', 'extend'];
+            'connect', 'disconnect', 'query', 'receive', 'task', 'transact', 'error', 'extend', 'defaults'];
 
         if (!options.noWarnings) {
             for (var prop in options) {
@@ -158,8 +163,6 @@ function $main(options) {
     $npm.utils.addReadProp(options, 'promiseLib', options.promiseLib);
     $npm.utils.addReadProp(options, 'pgNative', !!options.pgNative);
 
-    config.options = options;
-
     // istanbul ignore next:
     // we do not cover code specific to Native Bindings
     if (options.pgNative) {
@@ -168,6 +171,16 @@ function $main(options) {
             throw new Error('Failed to initialize Native Bindings.');
         }
     }
+
+    if (options.defaults) {
+        Object.keys(options.defaults).forEach(k => {
+            pg.defaults[k] = options.defaults[k];
+        });
+
+        delete options.defaults;
+    }
+
+    config.options = options;
 
     var Database = require('./database')(config);
 

--- a/test/entrySpec.js
+++ b/test/entrySpec.js
@@ -156,6 +156,18 @@ describe("Library entry function", function () {
         });
     });
 
+    describe("with defaults for pg", function () {
+        it("must return a valid library object", function () {
+            var lib = header({
+                defaults: {
+                    parseInputDatesAsUTC: true
+                }
+            });
+            expect(typeof(lib.pgp)).toBe('function');
+            expect(lib.pgp.pg.defaults.parseInputDatesAsUTC).toBe(true);
+        })
+    });
+
     describe("with invalid options", function () {
         var txt;
         beforeEach(function (done) {


### PR DESCRIPTION
There're some useful settings that aren't currently configurable from pg-promise. This allows overriding them on a case-by-case basis.