### PR TITLE
Update Readme.md to note poor stack traces for default ES6 Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ var pgp = require('pg-promise')(options);
 
 [Promises/A+] libraries that implement a recognizable promise signature and work automatically:
 
-* **ES6 Promise** - used by default, though it doesn't have `done()` or `finally()`.
+* **ES6 Promise** - used by default, though it doesn't have `done()` or `finally()` and generates poor stack traces
 * [Bluebird] - best alternative all around;
 * [Promise] - very solid library;
 * [When] - quite old, not the best support;


### PR DESCRIPTION
We can use this as a starting point if this is not satisfactory. Not sure how minimal or descriptive you would like this to be. I can include examples of bad stack traces, but I didn't want to clutter docs much further without your consent.