### PR TITLE
count parameters for QueryFiles

### DIFF
--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -25,6 +25,12 @@ const fmMap = {
     '#': fmFlags.value
 };
 
+const patterns = {
+    object: /\$(?:({)|(\()|(<)|(\[)|(\/))\s*[a-zA-Z0-9$_]+(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?\s*(?:(?=\2)(?=\3)(?=\4)(?=\5)}|(?=\1)(?=\3)(?=\4)(?=\5)\)|(?=\1)(?=\2)(?=\4)(?=\5)>|(?=\1)(?=\2)(?=\3)(?=\5)]|(?=\1)(?=\2)(?=\3)(?=\4)\/)/g,
+    array: /\$([1-9][0-9]{0,16}(?![0-9])(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?)/g,
+    value: /\$1(?![0-9])(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?/g
+};
+
 const maxVariable = 100000; // maximum supported variable is '$100000'
 
 ////////////////////////////////////////////////////
@@ -113,8 +119,7 @@ const formatAs = {
 
     object: (query, obj, raw, options) => {
         options = options && typeof options === 'object' ? options : {};
-        const pattern = /\$(?:({)|(\()|(<)|(\[)|(\/))\s*[a-zA-Z0-9$_]+(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?\s*(?:(?=\2)(?=\3)(?=\4)(?=\5)}|(?=\1)(?=\3)(?=\4)(?=\5)\)|(?=\1)(?=\2)(?=\4)(?=\5)>|(?=\1)(?=\2)(?=\3)(?=\5)]|(?=\1)(?=\2)(?=\3)(?=\4)\/)/g;
-        return query.replace(pattern, name => {
+        return query.replace(patterns.object, name => {
             const v = formatAs.stripName(name.replace(/^\$[{(<[/]|[\s})>\]/]/g, ''), raw);
             if (v.name in obj) {
                 return formatValue(obj[v.name], v.fm, obj);
@@ -136,7 +141,7 @@ const formatAs = {
 
     array: (query, array, raw, options) => {
         options = options && typeof options === 'object' ? options : {};
-        return query.replace(/\$([1-9][0-9]{0,16}(?![0-9])(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?)/g, name => {
+        return query.replace(patterns.array, name => {
             const v = formatAs.stripName(name.substr(1), raw);
             const idx = v.name - 1;
             if (idx >= maxVariable) {
@@ -157,7 +162,7 @@ const formatAs = {
     },
 
     value: (query, value, raw) => {
-        return query.replace(/\$1(?![0-9])(\^|~|#|:raw|:alias|:name|:json|:csv|:value)?/g, name => {
+        return query.replace(patterns.value, name => {
             const v = formatAs.stripName(name, raw);
             return formatValue(value, v.fm);
         });
@@ -739,7 +744,8 @@ Object.freeze($as);
 module.exports = {
     formatQuery: $formatQuery,
     formatFunction: $formatFunction,
-    as: $as
+    as: $as,
+    patterns: patterns
 };
 
 /**

--- a/lib/queryFile.js
+++ b/lib/queryFile.js
@@ -8,6 +8,7 @@ const $npm = {
     minify: require('pg-minify'),
     utils: require('./utils'),
     format: require('./formatting').as.format,
+    patterns: require('./formatting').patterns,
     QueryFileError: require('./errors/queryFile')
 };
 
@@ -225,6 +226,22 @@ function QueryFile(file, options) {
     });
 
     /**
+     * @name QueryFile#paramCount
+     * @type {number}
+     * @default 0
+     * @readonly
+     * @description
+     * When not in an error state, gives the number of parameters the QueryFile expects.
+     */
+    Object.defineProperty(this, 'paramCount', {
+        get: () => Object.keys($npm.patterns).reduce((count, pattern) => {
+          const match = sql.match($npm.patterns[pattern]);
+
+          return count + (match ? match.length : 0);
+        }, 0)
+    });
+
+    /**
      * @name QueryFile#error
      * @type {errors.QueryFileError}
      * @default undefined
@@ -292,6 +309,7 @@ QueryFile.prototype.toString = function (level) {
         lines.push(gap + 'error: ' + this.error.toString(level + 1));
     } else {
         lines.push(gap + 'query: "' + this.query + '"');
+        lines.push(gap + 'paramCount: ' + this.paramCount);
     }
     lines.push($npm.utils.messageGap(level) + '}');
     return lines.join($npm.os.EOL);

--- a/test/fileSpec.js
+++ b/test/fileSpec.js
@@ -48,6 +48,9 @@ describe('QueryFile / Positive:', function () {
         it('must return minified query', function () {
             expect(qf.query).toBe('select * from users');
         });
+        it('must count parameters', function () {
+            expect(qf.paramCount).toBe(0);
+        });
     });
 
     describe('default with params', function () {
@@ -58,6 +61,9 @@ describe('QueryFile / Positive:', function () {
         var qf = new QueryFile(sqlParams, {minify: true, params: params, noWarnings: true});
         it('must return pre-formatted query', function () {
             expect(qf.query).toBe('SELECT ${column~} FROM "public"."users"');
+        });
+        it('must count parameters', function () {
+            expect(qf.paramCount).toBe(1);
         });
     });
 


### PR DESCRIPTION
Since Massive allows use of an options object when invoking QueryFiles and using named parameters _also_ involves an object, it became impossible to tell whether a single object passed to a QueryFile invocation was intended to be a parameter map or query options without knowing if the QueryFile expected any parameters. Since file processing happens here, this seemed to be the place to put that :)