### PR TITLE
types: added return type to task() and tx()

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -419,15 +419,15 @@ declare namespace pgPromise {
 
         // Tasks
         // API: http://vitaly-t.github.io/pg-promise/Database.html#task
-        task(cb: (t: ITask<Ext> & Ext) => any): XPromise<any>
+        task<T>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
-        task(tag: any, cb: (t: ITask<Ext> & Ext) => any): XPromise<any>
+        task<T>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
         // Transactions
         // API: http://vitaly-t.github.io/pg-promise/Database.html#tx
-        tx(cb: (t: ITask<Ext> & Ext) => any): XPromise<any>
+        tx<T>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
-        tx(tag: any, cb: (t: ITask<Ext> & Ext) => any): XPromise<any>
+        tx<T>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
     }
 
     // Database object in connected state;

--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -419,15 +419,15 @@ declare namespace pgPromise {
 
         // Tasks
         // API: http://vitaly-t.github.io/pg-promise/Database.html#task
-        task<T>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
+        task<T=any>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
-        task<T>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
+        task<T=any>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
         // Transactions
         // API: http://vitaly-t.github.io/pg-promise/Database.html#tx
-        tx<T>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
+        tx<T=any>(cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
 
-        tx<T>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
+        tx<T=any>(tag: any, cb: (t: ITask<Ext> & Ext) => T): XPromise<T>
     }
 
     // Database object in connected state;


### PR DESCRIPTION
Instead of using `any` as a return type for `task()` or `tx()`, we can now specify a type or let typescript infer the type.

Screenshot of typings in production:

<img width="543" alt="screen shot 2017-07-24 at 16 17 25" src="https://user-images.githubusercontent.com/9661903/28527746-cc988238-708b-11e7-98bb-11d6088f4287.png">

Typescript can correctly infer and validate types.
