### PR TITLE
When need to insert empty array switch to literal array syntax to avoid empty array cast error

### DIFF
--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -93,6 +93,9 @@ function formatValue(value, fm, cc) {
 // as per PostgreSQL documentation: http://www.postgresql.org/docs/9.4/static/arrays.html
 // Arrays of any depth/dimension are supported.
 function formatArray(array) {
+    if(array.length === 0) {
+        return '\'{}\'';
+    }
     const loop = a => '[' + a.map(v => v instanceof Array ? loop(v) : formatValue(v)).join() + ']';
     return 'array' + loop(array);
 }

--- a/test/formatSpec.js
+++ b/test/formatSpec.js
@@ -348,7 +348,7 @@ describe('Method as.csv', function () {
 
         expect(pgp.as.csv()).toBe(''); // test undefined;
         expect(pgp.as.csv([])).toBe(''); // test empty array;
-        expect(pgp.as.csv([[]])).toBe('array[]'); // test empty array;
+        expect(pgp.as.csv([[]])).toBe('\'{}\''); // test empty array;
         expect(pgp.as.csv(null)).toBe('null'); // test null;
         expect(pgp.as.csv([null])).toBe('null'); // test null in array;
         expect(pgp.as.csv([undefined])).toBe('null'); // test undefined in array;
@@ -440,7 +440,7 @@ describe('Method as.array', function () {
     it('must correctly convert an empty array or value', function () {
         expect(pgp.as.array()).toBe('null');
         expect(pgp.as.array(null)).toBe('null');
-        expect(pgp.as.array([])).toBe('array[]');
+        expect(pgp.as.array([])).toBe('\'{}\'');
     });
 
     it('must correctly convert multi-dimension arrays', function () {


### PR DESCRIPTION
When i am trying to do update text[] column with [] i am getting such PG error:
```
error: cannot determine type of empty array
  at Connection.parseE (/mnt/d/Projects/InGo/API/node_modules/pg/lib/connection.js:567:11)
...
```
This happen because of attempt to use array[] as a value replacement.

I googled a lot of discussion about this ([1](https://github.com/postgraphql/postgraphql/issues/406), [2](https://www.postgresql.org/message-id/14071.1461292673@sss.pgh.pa.us) most relevant).

May i know the reason why you decide to do your own formatting and not pass text and values directly to pg module?

imo your tests very weak at this point.
If you decide to do your own formatting you should have integration tests and test update/insert using your formatting. 
