### PR TITLE
Changing the order of the IMain signature overloads

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -364,8 +364,6 @@ declare namespace pgPromise {
     interface IMain {
         <T>(cn: string | TConfig, dc?: any): IDatabase<T> & T
 
-        (cn: string | TConfig, dc?: any): IDatabase<IEmptyExt>
-
         readonly PromiseAdapter: typeof PromiseAdapter
         readonly PreparedStatement: typeof PreparedStatement
         readonly ParameterizedQuery: typeof ParameterizedQuery

--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -362,9 +362,9 @@ declare namespace pgPromise {
     // Post-initialization interface;
     // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
     interface IMain {
-        (cn: string | TConfig, dc?: any): IDatabase<IEmptyExt>
-
         <T>(cn: string | TConfig, dc?: any): IDatabase<T> & T
+
+        (cn: string | TConfig, dc?: any): IDatabase<IEmptyExt>
 
         readonly PromiseAdapter: typeof PromiseAdapter
         readonly PreparedStatement: typeof PreparedStatement


### PR DESCRIPTION
Changing the order of the IMain signatures so that the more
specific generic definitions can be inferred without casting

Due to how TS chooses matches for overloads the original ordering
causes the first overload to always be inferred by tsc, see
https://www.typescriptlang.org/docs/handbook/functions.html

With this change, you can now invoke the function and have the
inferred typing work correctly with all strict tsconfig.json
settings enabled and no casts, for example these
examples (taken from pg-promise-demo) now work as expected:

```js
const db: IDatabase<IExtensions> & IExtensions = pgp(config);
const db = <IDatabase<IExtensions> & IExtensions>pgp(config);
```

Before this change, these statements would not work with strict
tsconfig.json settings