### PR TITLE
Fix #507: add `schema` option to type definitions

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -651,6 +651,7 @@ declare namespace pgPromise {
         extend?: (obj: IDatabase<Ext> & Ext, dc: any) => void
         noLocking?: boolean
         capSQL?: boolean
+        schema?: string | string[]
     }
 
     // API: http://vitaly-t.github.io/pg-promise/Database.html#$config


### PR DESCRIPTION
8.3.0 added the `schema` initOption: https://github.com/vitaly-t/pg-promise/releases/tag/v.8.3.0

This PR also adds it to the type definitions.