### PR TITLE
Pipe returned stream into a Transform stream and return that instead

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -12,7 +12,8 @@
 const npm = {
     events: require('./events'),
     utils: require('./utils'),
-    text: require('./text')
+    text: require('./text'),
+    Transform: require('stream').Transform
 };
 
 ////////////////////////////////////////////
@@ -50,12 +51,22 @@ function $stream(ctx, qs, initCB, config) {
 
     const stream = ctx.db.client.query(qs);
 
-    stream.on('data', onData);
+    /* Pipe into a Transform stream so we can count number of rows without using a listener
+    on the underlying stream. This avoids returning a stream already in the flowing state. */
+    const returnStream = new npm.Transform({
+        objectMode: true,
+        transform: (data, encoding, callback) => {
+            callback(null, data);
+            onData(data);
+        }
+    });
+
+    stream.pipe(returnStream);
     stream.on('error', onError);
     stream.on('end', onEnd);
 
     try {
-        initCB.call(this, stream); // the stream must be initialized during the call;
+        initCB.call(this, returnStream);
     } catch (e) {
         release();
         error = getError(e);
@@ -75,6 +86,7 @@ function $stream(ctx, qs, initCB, config) {
     }
 
     function onError(e) {
+        returnStream.emit(e);
         release();
         stream.close();
         e = getError(e);
@@ -92,7 +104,6 @@ function $stream(ctx, qs, initCB, config) {
     }
 
     function release() {
-        stream.removeListener('data', onData);
         stream.removeListener('error', onError);
         stream.removeListener('end', onEnd);
     }


### PR DESCRIPTION
Piping returned stream into a Transform stream, so that it can be returned in the paused state (without any other data listeners). Existing functionality of row counting etc is maintained. Fixes Issue #541 