### PR TITLE
Tweak TypeScript return type for `oneOrNone`

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -380,7 +380,7 @@ declare namespace pgPromise {
         one<T = any>(query: TQuery, values?: any, cb?: (value: any) => T, thisArg?: any): XPromise<T>
 
         // API: http://vitaly-t.github.io/pg-promise/Database.html#oneOrNone
-        oneOrNone<T = any>(query: TQuery, values?: any, cb?: (value: any) => T, thisArg?: any): XPromise<T>
+        oneOrNone<T = any>(query: TQuery, values?: any, cb?: (value: any) => T, thisArg?: any): XPromise<T | null>
 
         // API: http://vitaly-t.github.io/pg-promise/Database.html#many
         many<T = any>(query: TQuery, values?: any): XPromise<T[]>


### PR DESCRIPTION
Since `oneOrNone` can return null, it's probably more ergonomic to write `oneOrNone<{ foo: "bar" }>(...)` than `oneOrNone<{ foo: "bar"} | null>(...)`