### PR TITLE
Handle statement timeout as a special case

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -229,10 +229,11 @@ function addInspection(type, cb) {
 function isConnectivityError(err) {
     const code = err && typeof err.code === 'string' && err.code;
     const cls = code && code.substr(0, 2); // Error Class
-    return code === 'ECONNRESET' || cls === '08' || cls === '57';
+    return code === 'ECONNRESET' || cls === '08' || (cls === '57' && code !== '57014');
     // Code 'ECONNRESET' - Connectivity issue handled by the driver.
     // Class 08 - Connection Exception.
     // Class 57 - Operator Intervention.
+    //       57014 - Query canceled, issued when statement timeout stops query.
     //
     // ERROR CODES: https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html
 }


### PR DESCRIPTION
This is a fix for the issue #566 with the repro https://gist.github.com/joux3/a29727968f7195eb640959013fab319f.

A quick grep through postgresql codebase reveals three spots where `57014` is used:
1. auth timeout
2. statement timeout
3. when a error happens in `COPY`

Therefore I believe this should not break any other functionality. Would a test case for this behaviour be needed too?