### PR TITLE
Propagate client errors properly upon disconnect

### DIFF
--- a/lib/cnContext.js
+++ b/lib/cnContext.js
@@ -58,9 +58,9 @@ class ConnectionContext {
         this.start = new Date();
     }
 
-    disconnect() {
+    disconnect(err) {
         if (this.db) {
-            this.db.done();
+            this.db.done(err);
             this.db = null;
         }
     }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -107,7 +107,7 @@ function onError(err) {
     const ctx = this.$ctx;
     const cn = npm.utils.getSafeConnection(ctx.cn);
     npm.events.error(ctx.options, err, {cn, dc: ctx.dc});
-    ctx.disconnect();
+    ctx.disconnect(err);
     if (ctx.cnOptions && typeof ctx.cnOptions.onLost === 'function' && !ctx.notified) {
         try {
             ctx.cnOptions.onLost.call(this, err, {


### PR DESCRIPTION
Pg-promise doesn't propagate `err` to `disconnect` action, therefore, the connection in question becomes staled.

This PR aims to propagate the `err` to `disconnect` action, and hence `done(err)`. In that way, pool library can properly `release` and `remove` the client from the pool.