### PR TITLE
fix: {minify: 'after'} was broken in queryFile

### DIFF
--- a/lib/queryFile.js
+++ b/lib/queryFile.js
@@ -172,7 +172,7 @@ function QueryFile(file, options) {
         try {
             sql = npm.fs.readFileSync(filePath, 'utf8');
             modTime = lastMod || npm.fs.statSync(filePath).mtime.getTime();
-            if (opt.minify && !opt.minify !== 'after') {
+            if (opt.minify && opt.minify !== 'after') {
                 sql = npm.minify(sql, {compress: opt.compress});
             }
             if (opt.params !== undefined) {


### PR DESCRIPTION
`!opt.minify` is always `false` so `!opt.minify !== 'after'` is always `true`. I think you meant to just test that `opt.minify` is not `'after'`