### PR TITLE
stream: complete if stream is closed but does not emit end or error

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -63,6 +63,8 @@ function $stream(ctx, qs, initCB, config) {
         return $p.reject(error);
     }
 
+    stream.on('close', onEnd);
+
     const start = Date.now();
     let resolve, reject, nRows = 0, cache = [];
 
@@ -95,6 +97,7 @@ function $stream(ctx, qs, initCB, config) {
         stream.removeListener('data', onData);
         stream.removeListener('error', onError);
         stream.removeListener('end', onEnd);
+        stream.removeListener('close', onEnd);
     }
 
     function notify() {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jasmine-node": "1.16.2",
     "jsdoc": "3.5.5",
     "pg-query-stream": "2.0.0",
+    "pump": "^3.0.0",
     "typescript": "3.3.4000"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "lib/index.js",
   "typings": "typescript/pg-promise.d.ts",
   "scripts": {
-    "test": "jasmine-node test",
+    "test": "jasmine-node test --captureExceptions",
     "test:native": "jasmine-node test --config PG_NATIVE true",
     "doc": "./node_modules/.bin/jsdoc -c ./jsdoc/jsdoc.js ./jsdoc/README.md -t ./jsdoc/templates/custom",
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test",
-    "travis": "npm run lint && npm run tslint && istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test --captureExceptions && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "travis": "npm run lint && npm run tslint && istanbul cover ./node_modules/jasmine-node/bin/jasmine-node -- test --captureExceptions && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "lint": "./node_modules/.bin/eslint ./lib ./test/*.js ./test/db",
     "tslint": "./node_modules/.bin/tslint ./typescript/*.ts"
   },


### PR DESCRIPTION
### Problem
I ran into a problem in a service of mine, where were streaming results from the database down to a client. Specifically, I have streams in a `stream.pipeline` in Node 10 (which is comparable to the `pump` module).

If the query completes, everything is wrapped up nicely and nothing goes wrong.

However, if the connection [to the client] is severed before the query is completed fully, response will close, and `pump` would close the query stream. In this case, neither the `error` event nor the `end` event are emitted, which lead to the promise wrapping the stream to be held open indefinitely, which then lead to my service running out of connections in the db pool.

### Solution

I added a listener to the close event on the stream, which resolves the promise and allows the query to be returned to the pool.

### Tests Added

1. "Method stream with downstream error through pump must return the correct data"

To simulate a downstream error, I use a transform stream that emits an error instead of transforming data, and wrap the two streams in a `pump` pipeline. 

Without the fix applied, this test fails because of a timeout. With the fix applied, this test and all others pass.

2. "Method stream with initialization closing the stream must return with zero processed"

My initial implementation was to attach the `close` event listener with the other listeners. In doing so, a different test triggered an uncaught error because the cache and nRows variables were not yet defined. To work around that test failing, I moved the listener attachment to be after initialization.

I then added this test, because I wanted to make sure nothing was broken if someone did close the stream in initialization. This test will now pass, because of this fix.

### Assumptions Made

1. I assumed that if the stream closes but doesn't error, then this stream method should resolve and not reject. I'm not partial to this assumption, it just seemed appropriate.
2. I assumed that the pg-query-stream implementation is not faulty. I actually spent a while trying to write up test cases for that project. Eventually, I came to the question: "Should PgQueryStream emit an end event if it was interrupted?" I wasn't sure, but since it _is_ emitting a close event, I came here to open this PR.

### Workaround

To get a fix out to my service immediately, I had to explicitly call destroy on the query stream, to prompt it to emit an error event and complete the response. My work around looked like this:

```js
pump(
  queryStream,
  JSONStream.stringify(),
  response,
  (error)=>{
    if(error){
      queryStream.destroy(error);
      logger.error("Streaming Error", error);
    }
  }
)
```
