### PR TITLE
Fix error handling

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -107,7 +107,6 @@ function onError(err) {
     const ctx = this.$ctx;
     const cn = npm.utils.getSafeConnection(ctx.cn);
     npm.events.error(ctx.options, err, {cn, dc: ctx.dc});
-    ctx.disconnect(err);
     if (ctx.cnOptions && typeof ctx.cnOptions.onLost === 'function' && !ctx.notified) {
         try {
             ctx.cnOptions.onLost.call(this, err, {

--- a/lib/database.js
+++ b/lib/database.js
@@ -1614,7 +1614,7 @@ function Database(cn, dc, config) {
 // which cannot be tested automatically; removing from coverage:
 // istanbul ignore next
 function onError(err) {
-    const ctx = err.client.$ctx;
+    const ctx = err.client.$ctx || {};
     npm.events.error(ctx.options, err, {
         cn: npm.utils.getSafeConnection(ctx.cn),
         dc: ctx.dc

--- a/lib/database.js
+++ b/lib/database.js
@@ -1614,7 +1614,12 @@ function Database(cn, dc, config) {
 // which cannot be tested automatically; removing from coverage:
 // istanbul ignore next
 function onError(err) {
-    const ctx = err.client.$ctx || {};
+    // this client was never seen by pg-promise, which
+    // can happen if it failed to initialize
+    if (!err.client.$ctx) {
+        return;
+    }
+    const ctx = err.client.$ctx;
     npm.events.error(ctx.options, err, {
         cn: npm.utils.getSafeConnection(ctx.cn),
         dc: ctx.dc

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "typescript/pg-promise.d.ts",
   "scripts": {
-    "test": "jasmine-node test",
+    "test": "jasmine-node --captureExceptions test",
     "test:native": "jasmine-node test --config PG_NATIVE true",
     "doc": "./node_modules/.bin/jsdoc -c ./jsdoc/jsdoc.js ./jsdoc/README.md -t ./jsdoc/templates/custom",
     "coverage": "istanbul cover ./node_modules/jasmine-node/bin/jasmine-node test",
@@ -41,11 +41,11 @@
     "npm": ">=2.15"
   },
   "dependencies": {
+    "assert-options": "0.1.3",
     "manakin": "0.5.2",
     "pg": "7.9.0",
     "pg-minify": "1.0.0",
-    "spex": "2.2.0",
-    "assert-options": "0.1.3"
+    "spex": "2.2.0"
   },
   "devDependencies": {
     "@types/node": "11.13.4",

--- a/test/db/header.js
+++ b/test/db/header.js
@@ -16,7 +16,7 @@ defPromise.config({
 const cn = {
     host: 'localhost', // server name or IP address;
     port: 5432, // default port;
-    database: 'pg_promise_test', // local database name for testing;
+    database: 'postgres', // local database name for testing;
     user: 'postgres' // user name;
     // password: - add password, if needed;
 };


### PR DESCRIPTION
When an error is emitted by the pool, before pg-promise received the
client, the error handling failed with:

> TypeError: Cannot read property 'options' of undefined

Try to log pool errors best effort.

---

When an in-use client receives an error rely on the caller to end the
connection instead of doing it in the error handler to prevent releasing
the same connection twice.

Fixes https://github.com/vitaly-t/pg-promise/issues/599
Fixes https://github.com/vitaly-t/pg-promise/issues/600


Requires https://github.com/brianc/node-pg-pool/pull/123