### PR TITLE
Fix protocol violations not resulting in a rollback

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -216,7 +216,7 @@ function isConnectivityError(err) {
     const code = err && typeof err.code === 'string' && err.code;
     const cls = code && code.substr(0, 2); // Error Class
     // istanbul ignore next (we cannot test-cover all error cases):
-    return code === 'ECONNRESET' || cls === '08' || (cls === '57' && code !== '57014');
+    return code === 'ECONNRESET' || (cls === '08' && code !== '08P01') || (cls === '57' && code !== '57014');
     // Code 'ECONNRESET' - Connectivity issue handled by the driver.
     // Class 08 - Connection Exception.
     // Class 57 - Operator Intervention (except for 57014, for cancelled queries).

--- a/test/dbSpec.js
+++ b/test/dbSpec.js
@@ -1467,6 +1467,27 @@ describe('Transactions', () => {
         });
     });
 
+    describe('Closing after a protocol violation', () => {
+        let error, value;
+        beforeEach(done => {
+            db.task(task =>
+                task.tx(tx => tx.one('select \'\u0000\''))
+                    .then(() => {
+                        throw new Error('expected error');
+                    }, () => {})
+                    .then(() => task.tx(tx => tx.one('select \'hi\' as v')))
+            ).then(row => {
+                value = row.v;
+            }, e => {
+                error = e;
+            }).then(done);
+        });
+        it('Must not have an error', () => {
+            expect(value).toEqual('hi');
+            expect(error).toEqual(undefined);
+        });
+    });
+
     describe('Closing after a connectivity issue', () => {
         let error, query;
         beforeEach(done => {


### PR DESCRIPTION
Errors of the class 08 ("Connection Exceptions") don't trigger an attempted rollback if encountered during a transaction. This is usually the right idea, except in the case of '08P01', which is a protocol violation and means that the connection is still viable.

A particular instance which has bitten us, where users can trigger protocol violations, is when the user input contains unicode null bytes. After a connection has failed with this 08P01 error, it is tossed back into the connection pool without a rollback, and every subsequent user of that connection gets a "current transaction is aborted" error for every query (because the "begin transaction" statement doesn't even succeed).

This commit fixes that bug. Below is a reproduction. 

Repro:

```
const pgp = require('pg-promise')();
const db = pgp({
  host: 'localhost',
  port: 5432,
  user: 'postgres',
  password: '',
  database: 'postgres',
  max: 1,
})

async function noRollbackExample() {
  try {
    await db.tx(tx => {
      return tx.one(`select $1`, ['\u0000']);
    })
  } catch(e) {
    console.log('caught', e);
  }

  try {
    db.tx(tx => {
      return tx.one('select 1');
    })
  } catch(e) {
    console.log('caught', e);
  }
}
```

