### PR TITLE
Enable safer typing of extensions

### DIFF
--- a/typescript/README.MD
+++ b/typescript/README.MD
@@ -30,7 +30,7 @@ interface IExtensions {
 }
 
 // pg-promise initialization options:
-const options = {
+const options: pgPromise.IInitOptions<IExtensions> = {
     extend(obj) {
         obj.findUser = userId => {
             return obj.one('SELECT * FROM Users WHERE id = $1', userId);
@@ -41,14 +41,14 @@ const options = {
 // initializing the library:
 const pgp = pgPromise(options);
 
-// database object with extensions:
-const db = pgp<IExtensions>('postgres://username:password@host:port/database');
+// database object:
+const db = pgp('postgres://username:password@host:port/database');
 
 // now you can use the extensions everywhere (including tasks and transactions):
 db.findUser(123).then(...);
 ```
 
-For a complete and comprehensive example, check out [pg-promise-demo]. 
+For a complete and comprehensive example, check out [pg-promise-demo].
 
 [pg-promise-demo]:https://github.com/vitaly-t/pg-promise-demo
 [extend]:http://vitaly-t.github.io/pg-promise/global.html#event:extend

--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -294,8 +294,8 @@ declare namespace pgPromise {
 
     // Post-initialization interface;
     // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
-    interface IMain {
-        <T>(cn: string | pg.IConnectionParameters, dc?: any): IDatabase<T> & T
+    interface IMain<Ext = {}> {
+        <T = Ext>(cn: string | pg.IConnectionParameters, dc?: any): IDatabase<T> & T
 
         readonly PromiseAdapter: typeof PromiseAdapter
         readonly PreparedStatement: typeof PreparedStatement
@@ -570,7 +570,7 @@ declare namespace pgPromise {
         promiseLib: any
         promise: IGenericPromise
         options: IInitOptions<Ext>
-        pgp: IMain
+        pgp: IMain<Ext>
         $npm: any
     }
 
@@ -669,6 +669,6 @@ declare namespace pgPromise {
 
 // Default library interface (before initialization)
 // API: http://vitaly-t.github.io/pg-promise/module-pg-promise.html
-declare function pgPromise(options?: pgPromise.IInitOptions): pgPromise.IMain
+declare function pgPromise<Ext = {}>(options?: pgPromise.IInitOptions<Ext>): pgPromise.IMain<Ext>
 
 export = pgPromise;


### PR DESCRIPTION
## Context

As of `pg-promise@9.0.2`, [dynamic protocol extensions](https://github.com/vitaly-t/pg-promise/blob/9.0.2/typescript/README.MD#with-extensions) are passed in pre-initialisation but typed post-initialisation. This can lead to mismatches between the supposed interface and the actual implementation:

```typescript
import pgPromise from 'pg-promise';

const options: pgPromise.IInitOptions<{ false: () => true }> = {
  extend: obj => {
    obj.false = () => true;
  }
};

// pre-initialisation
const pgp = pgPromise(options as any);

// post-initialisation
const db = pgp<{ false: () => false }>({});

const result: false = db.false();

console.log(result);
// true
```

Also note the `as any` type assertion; pre-initialisation is awkward to work with when it is not parametric (032d1de02a8667abc3b170372a8c419455eeda74):

```typescript
const options: pgPromise.IInitOptions<{ false: () => true }> = {
  extend: obj => {
    obj.false = () => true;
  }
};

const pgp = pgPromise(options);
// Type '{}' is not assignable to type '{ false: () => true; }'. ts(2345)
```

```typescript
const pgp = pgPromise({
  extend: obj => {
    obj.false = () => true;
    // Property 'false' does not exist on type 'IDatabase<{}>' .ts(2339)
  }
});
```

## Description

Make pre-initialisation parametric and pass extensions through to post-initialisation:

```typescript
const options: pgPromise.IInitOptions<{ false: () => false }> = {
  extend: obj => {
    obj.false = () => false;
  }
};

const pgp = pgPromise(options);
// pgPromise.IMain<{ false: () => false }>

const db = pgp({});
// pgPromise.IDatabase<{ false: () => false }> & { false: () => false }
```

```typescript
const pgp = pgPromise<{ false: () => false }>({
  extend: obj => {
    obj.false = () => false;
  }
});
// pgPromise.IMain<{ false: () => false }>

const db = pgp({});
// pgPromise.IDatabase<{ false: () => false }> & { false: () => false }
```

Newly-added type variables have default values for backwards compatibility.

## Contributing

- [x] `npm test`