### PR TITLE
Clarify docs on how to get query as string from queryfile

### DIFF
--- a/lib/query-file.js
+++ b/lib/query-file.js
@@ -272,7 +272,7 @@ const usedPath = {};
  *
  * ```js
  * const ctf = pgp.as.ctf; // Custom Type Formatting symbols namespace
- * const query = qf[ctf.toPostgres]; // qf = an object of type QueryFile
+ * const query = qf[ctf.toPostgres](); // qf = an object of type QueryFile
  * ```
  *
  * This is a raw formatting type (`rawType = true`), i.e. when used as a query-formatting parameter, type `QueryFile` injects SQL as raw text.


### PR DESCRIPTION
In the example, `query` is only reference to the method that gets the string.

For docs it's more useful to call the function so it's actually the query as string.