### PR TITLE
Transaction mode was not getting applied

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -1562,7 +1562,7 @@ function Database(cn, dc, config) {
             taskCtx.inTransaction = taskCtx.txLevel >= 0;
             taskCtx.level = taskCtx.level >= 0 ? (taskCtx.level + 1) : 0;
             taskCtx.cb = params.cb; // callback function;
-            taskCtx.mode = params.options.mode; // transaction mode;
+            taskCtx.mode = params.options; // transaction mode;
             if (this !== obj) {
                 taskCtx.context = this; // calling context object;
             }


### PR DESCRIPTION
params.options object did not have any property mode, which always turned into undefined and thus no transactions settings were applied.