### PR TITLE
Failing test for savepoint does not exist error

### DIFF
--- a/test/db.spec.js
+++ b/test/db.spec.js
@@ -2286,6 +2286,19 @@ describe(`Task`, () => {
         });
     });
 
+    describe(`inside a transaction / task`, () => {
+        iit(`must know it is in transaction`, (done) => {
+            db.tx(t => {
+                const a = t.tx(t1 => { });
+                const b = t.tx(t1 => { }); 
+                const c = t.tx(t1 => { });
+
+                return t.batch([a, b, c]);
+            })
+                .finally(done);
+        });
+    });
+
     describe(`with a callback that returns nothing`, () => {
         let result;
         beforeEach(done => {


### PR DESCRIPTION
This is a first pass for solving an issue with savepoints being release by higher-level savepoints

This is my first functional PR. Let me know if anything is needed

TODO: Replace `iit` for `it` in test suite

```
Unhandled rejection BatchError: savepoint "sp_1_2" does not exist
    at check (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/spex/lib/ext/batch.js:135:32)
    at step (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/spex/lib/ext/batch.js:109:17)
    at utils.resolve.call.reason (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/spex/lib/ext/batch.js:83:17)
    at value.then.catch.error (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/spex/lib/utils/index.js:62:25)
    at tryCatcher (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/dplewis/Documents/GitHub/pg-promise/node_modules/bluebird/js/release/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

P.S. I get two test failing running on Mac OS 10.15.7
```
 1) Connection for invalid connection must report the right error
   Message:
     Expected 'database "bla-bla" does not exist' to contain 'password authentication failed for user'.
   Stacktrace:
     Error: Expected 'database "bla-bla" does not exist' to contain 'password authentication failed for user'.
    at jasmine.Spec.it (/Users/dplewis/Documents/GitHub/pg-promise/test/db.spec.js:263:43)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)

  2) Connection for invalid user name must report the right error
   Message:
     Expected 'role "somebody" does not exist' to contain 'password authentication failed for user "somebody"'.
   Stacktrace:
     Error: Expected 'role "somebody" does not exist' to contain 'password authentication failed for user "somebody"'.
    at jasmine.Spec.it (/Users/dplewis/Documents/GitHub/pg-promise/test/db.spec.js:291:43)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)

Finished in 8.733 seconds
511 tests, 1592 assertions, 2 failures, 0 skipped
```