### PR TITLE
Separate table name from its column

### DIFF
--- a/lib/helpers/methods/insert.js
+++ b/lib/helpers/methods/insert.js
@@ -141,8 +141,8 @@ function insert(data, columns, table, capSQL) {
 }
 
 const sql = {
-    lowCase: `insert into $1^($2^) values`,
-    capCase: `INSERT INTO $1^($2^) VALUES`
+    lowCase: `insert into $1^ ($2^) values`,
+    capCase: `INSERT INTO $1^ ($2^) VALUES`
 };
 
 module.exports = {insert};


### PR DESCRIPTION
This way is easier to extract the table name in the `receive` event:
```
function receive(data, result, e) {
  const table = e.query.split(' ', 3)[2];
}
```