### PR TITLE
Enabled GitHub Actions to run CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  container-job:
+    runs-on: ubuntu-latest
+    container: node:16-bullseye
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_HOST: postgres
+          POSTGRES_DB: pg_promise_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - run: npm install
+    - run: node test/db/init.js
+    - run: npm test
+    - run: npm run coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   container-job:
     runs-on: ubuntu-latest
+    env:
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: pg_promise_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     container: node:16-bullseye
     services:
       postgres:

--- a/test/db/header.js
+++ b/test/db/header.js
@@ -16,8 +16,8 @@ const cn = {
     host: `localhost`, // server name or IP address;
     port: 5432, // default port;
     database: `pg_promise_test`, // local database name for testing;
-    user: `postgres` // user name;
-    // password: - add password, if needed;
+    user: `postgres`, // user name;
+    password: `postgres`
 };
 
 pgpLib.suppressErrors = true; // suppress console output for error messages;

--- a/test/db/header.js
+++ b/test/db/header.js
@@ -13,11 +13,11 @@ defPromise.config({
 // or the other way round - change the details to match your local configuration.
 const cn = {
     allowExitOnIdle: true,
-    host: `localhost`, // server name or IP address;
+    host: process.env.POSTGRES_HOST || `localhost`, // server name or IP address;
     port: 5432, // default port;
-    database: `pg_promise_test`, // local database name for testing;
-    user: `postgres`, // user name;
-    password: `postgres`
+    database: process.env.POSTGRES_DB || `pg_promise_test`, // local database name for testing;
+    user: process.env.POSTGRES_USER || `postgres`, // user name;
+    password: process.env.POSTGRES_PASSWORD || `postgres`
 };
 
 pgpLib.suppressErrors = true; // suppress console output for error messages;


### PR DESCRIPTION
This pull request enables GitHub Actions to run CI. There are 2 issues below then I have opened this pull request as draft one.

### TODO
- [ ] Address 7 `npm test` failures 
- [x] Use environment variables not to update `test/db/header.js` file

Fix #799