### PR TITLE
Add `variable` to `Column` type definition

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -166,6 +166,7 @@ declare namespace pgPromise {
         readonly def: any;
         readonly castText: string;
         readonly escapedName: string;
+        readonly variable: string;
         readonly init: (col: IColumnDescriptor<T>) => any
         readonly skip: (col: IColumnDescriptor<T>) => boolean
 


### PR DESCRIPTION
The type definitions for `Column` do not include the `variable` accessor, so this adds it.