### PR TITLE
Inject original query into driver errors

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -160,6 +160,7 @@ function $query(ctx, query, values, qrm, config) {
                     if (npm.utils.isConnectivityError(err)) {
                         ctx.db.client.$connectionError = err;
                     }
+                    if (!err.query) err.query = query;
                     error = err;
                 } else {
                     multiResult = Array.isArray(result);


### PR DESCRIPTION
Hey @vitaly-t , thanks for your work on the library! Would you agree to merge in this change?

The reasoning behind it is the following. The errors created by your library, like [QueryResultError](http://vitaly-t.github.io/pg-promise/errors.QueryResultError.html) do include the original `query` field, which is cool and very helpful. However, errors returned directly from the NodeJS PostgreSQL driver don't include it. For example, if you run smth like

```js
db.one('SELECT * FROM some_table WHERE LIMIT 1');
```

The error will be an instance of [`pg-protocol`'s DatabaseError](https://github.com/brianc/node-postgres/blob/master/packages/pg-protocol/src/messages.ts#L97-L117), saying `syntax error at or near "LIMIT"`, but including no further details on what query failed and where (and as it is thrown from async code, the stack trace does not include the original source location where the query was fired).

The line I suggest injects the original query into the error.
