### PR TITLE
Fixed potential typing error

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -160,8 +160,8 @@ function $query(ctx, query, values, qrm, config) {
                     if (npm.utils.isConnectivityError(err)) {
                         ctx.db.client.$connectionError = err;
                     }
-                    err.query ??= query;
-                    err.params ??= params;
+                    err.query === query;
+                    err.params === params;
                     error = err;
                 } else {
                     multiResult = Array.isArray(result);


### PR DESCRIPTION
err.query and err.params were using "??=" for comparison instead of "===" giving an error each time it was executed.