### PR TITLE
Run tests against Postgres 14 and 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,18 @@ jobs:
           - name: PostgreSQL 13, Node 16
             POSTGRES_IMAGE: postgres:13
             NODE_VERSION: 16
+          - name: PostgreSQL 14, Node 14
+            POSTGRES_IMAGE: postgres:14
+            NODE_VERSION: 14
+          - name: PostgreSQL 14, Node 16
+            POSTGRES_IMAGE: postgres:14
+            NODE_VERSION: 16
+          - name: PostgreSQL 15, Node 14
+            POSTGRES_IMAGE: postgres:15
+            NODE_VERSION: 14
+          - name: PostgreSQL 15, Node 16
+            POSTGRES_IMAGE: postgres:15
+            NODE_VERSION: 16
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15
@@ -83,3 +95,6 @@ jobs:
         run: npm run test:init
       - name: Test and Coverage
         run: npm run coverage
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 pg-promise
 ==========
 
+[![Build Status](https://github.com/vitaly-t/pg-promise/workflows/ci/badge.svg?branch=master)](https://github.com/vitaly-t/pg-promise/actions?query=workflow%3Aci+branch%3Amaster)
+[![Node Version](https://img.shields.io/badge/nodejs-14,_16-green.svg?logo=node.js&style=flat)](https://nodejs.org)
+[![Postgres Version](https://img.shields.io/badge/postgresql-11,_12,_13,_14,_15-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
+
+---
+
 PostgreSQL interface for Node.js
 
 ---


### PR DESCRIPTION
- Adds badges to README
- Add [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) to Github Actions
- Postgres 14 and 15 support

<img width="384" alt="Screen Shot 2022-12-30 at 4 45 50 PM" src="https://user-images.githubusercontent.com/9830365/210116388-5099f4db-ebc9-4a2d-9c15-3440266a6678.png">
