### PR TITLE
Fix node-postgres.com/apis/... links

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -1679,5 +1679,5 @@ module.exports = config => {
 
 /**
  * @external Result
- * @see https://node-postgres.com/api/result
+ * @see https://node-postgres.com/apis/result
  */

--- a/lib/main.js
+++ b/lib/main.js
@@ -415,7 +415,7 @@ module.exports = $main;
 
 /**
  * @external Client
- * @see https://node-postgres.com/api/client
+ * @see https://node-postgres.com/apis/client
  */
 
 /**


### PR DESCRIPTION
It's /apis/... not /api/...

I'm not sure how the github-pages bundling works, but there are dead links in the docs site (e.g. the `external:Result` link in https://vitaly-t.github.io/pg-promise/global.html#event:receive). I guessed that they come from these jsdoc comments.