### PR TITLE
[docs] added margin to section

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,6 +10,10 @@ html, body, section {
     background-color: #F0F0F0;
 }
 
+section {
+    margin-left: 10px;
+}
+
 pre.prettyprint:not(pre.source) {
     width: auto;
     border: 1px solid lightgrey;


### PR DESCRIPTION
Hello, thank you for the wonderful repository.
I was viewing the documents using Chrome, but I fixed it because the scrollbar and text were overlapping.
I am using Chrome 123.

before
<img width="1302" alt="スクリーンショット 2024-04-01 午前1 06 53" src="https://github.com/vitaly-t/pg-promise/assets/69191307/6a34aa3d-399d-4ca5-ad51-ab500038c951">

after
<img width="992" alt="スクリーンショット 2024-04-01 午前1 06 39" src="https://github.com/vitaly-t/pg-promise/assets/69191307/ce188a88-251d-433f-89a4-015bf8682c6a">

⚠️ This is my very first PR to this repository, so I might be missing something important.