### PR TITLE
Extra context of query file execution

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -42,7 +42,7 @@ function $query(ctx, query, values, qrm, config) {
     const opt = ctx.options,
         capSQL = opt.capSQL;
 
-    let error, entityType,
+    let error, entityType, queryFilePath,
         pgFormatting = opt.pgFormatting,
         params = pgFormatting ? values : undefined;
 
@@ -67,6 +67,7 @@ function $query(ctx, query, values, qrm, config) {
                 error = query.error;
                 query = query.file;
             } else {
+                queryFilePath = query.file;
                 query = query[QueryFile.$query];
             }
         } else {
@@ -240,7 +241,7 @@ function $query(ctx, query, values, qrm, config) {
                 error = new Error(npm.text.looseQuery);
             }
             return {
-                client, query, params,
+                client, query, params, queryFilePath, values,
                 dc: ctx.dc,
                 ctx: ctx.ctx
             };

--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -508,7 +508,9 @@ declare namespace pgPromise {
         cn: any
         dc: any
         query: any
-        params: any
+        params: any,
+        values: any,
+        queryFilePath?: string, 
         ctx: ITaskContext
     }
 


### PR DESCRIPTION
While pg-promise already provides the full query as it was sent to the DB in the context object that is provided to the error callback, with large or complex queries being able to get the path to the source SQL file and the values passed to it when running the query would be really helpful for debugging and monitoring purposes.

The proposed changes add the path to the query file and the values used to execute it to the EventContext.