### PR TITLE
Enhance types for `extend` and `merge` of `ColumnSet`

### DIFF
--- a/typescript/pg-promise.d.ts
+++ b/typescript/pg-promise.d.ts
@@ -206,9 +206,11 @@ declare namespace pgPromise {
             skip?: string | string[] | ((c: Column<T>) => boolean)
         }): string
 
-        extend<S>(columns: Column<T> | ColumnSet<T> | Array<string | IColumnConfig<T> | Column<T>>): ColumnSet<S>
+        extend<K extends string>(columns: K[]): ColumnSet<T & Record<K, unknown>>
+        extend<S>(columns: Column<S> | ColumnSet<S> | Array<IColumnConfig<S> | Column<S>>): ColumnSet<T & S>
 
-        merge<S>(columns: Column<T> | ColumnSet<T> | Array<string | IColumnConfig<T> | Column<T>>): ColumnSet<S>
+        merge<K extends string>(columns: K[]): ColumnSet<T & Record<K, unknown>>
+        merge<S>(columns: Column<S> | ColumnSet<S> | Array<IColumnConfig<S> | Column<S>>): ColumnSet<T & S>
 
         prepare(obj: object): object
 


### PR DESCRIPTION
As of now, you cannot `extend` or `merge` a `source` because the type is written such that `source` has to have the same structural form as `destination`.

```ts
const destination: pgp.ColumnSet<{ destination: string }> = new ColumnSet([{ name: 'destination' }]);
const source: pgp.ColumnSet<{ source: string }> = new ColumnSet([{ name: 'source' }]);

const both = destination.extend(source); // TS error: Property destination is missing in type { source: string } but required in type { destination: string }
```

The fix is to use `S` as an "input" (source) type (the type we are merging with) and return `T & S` as the result.
```ts
const destination: pgp.ColumnSet<{ destination: string }> = new ColumnSet([{ name: 'destination' }]);
const source: pgp.ColumnSet<{ source: string }> = new ColumnSet([{ name: 'source' }]);

const both = destination.extend(source); // TS happy: type of both is pgp.ColumnSet<{ destination: string; } & { source: string; }>
```

This is not a perfect solution as there are still some edge cases, but it's a good compromise that covers the most common use cases.