### PR TITLE
Remove legacy inspections

### DIFF
--- a/lib/errors/parameterized-query-error.js
+++ b/lib/errors/parameterized-query-error.js
@@ -11,7 +11,8 @@ const {QueryFileError} = require('./query-file-error');
 
 const npm = {
     os: require('os'),
-    utils: require('../utils')
+    utils: require('../utils'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -56,40 +57,15 @@ class ParameterizedQueryError extends Error {
     }
 }
 
-/**
- * @method errors.ParameterizedQueryError#toString
- * @description
- * Creates a well-formatted multi-line string that represents the error.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-ParameterizedQueryError.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        gap2 = npm.utils.messageGap(level + 2),
-        lines = [
-            'ParameterizedQueryError {',
-            gap1 + 'message: "' + this.message + '"',
-            gap1 + 'result: {',
-            gap2 + 'text: ' + npm.utils.toJson(this.result.text),
-            gap2 + 'values: ' + npm.utils.toJson(this.result.values),
-            gap1 + '}'
-        ];
-    if (this.error) {
-        lines.push(gap1 + 'error: ' + this.error.toString(level + 1));
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
 npm.utils.addInspection(ParameterizedQueryError, function () {
-    return this.toString();
+    const obj = {
+        message: this.message,
+        result: this.result
+    };
+    if (this.error) {
+        obj.error = this.error;
+    }
+    return 'ParameterizedQueryError ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 module.exports = {ParameterizedQueryError};

--- a/lib/errors/prepared-statement-error.js
+++ b/lib/errors/prepared-statement-error.js
@@ -11,7 +11,8 @@ const {QueryFileError} = require('./query-file-error');
 
 const npm = {
     os: require('os'),
-    utils: require('../utils')
+    utils: require('../utils'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -56,41 +57,15 @@ class PreparedStatementError extends Error {
     }
 }
 
-/**
- * @method errors.PreparedStatementError#toString
- * @description
- * Creates a well-formatted multi-line string that represents the error.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-PreparedStatementError.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        gap2 = npm.utils.messageGap(level + 2),
-        lines = [
-            'PreparedStatementError {',
-            gap1 + 'message: "' + this.message + '"',
-            gap1 + 'result: {',
-            gap2 + 'name: ' + npm.utils.toJson(this.result.name),
-            gap2 + 'text: ' + npm.utils.toJson(this.result.text),
-            gap2 + 'values: ' + npm.utils.toJson(this.result.values),
-            gap1 + '}'
-        ];
-    if (this.error) {
-        lines.push(gap1 + 'error: ' + this.error.toString(level + 1));
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
 npm.utils.addInspection(PreparedStatementError, function () {
-    return this.toString();
+    const obj = {
+        message: this.message,
+        result: this.result
+    };
+    if (this.error) {
+        obj.error = this.error;
+    }
+    return 'PreparedStatementError ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 module.exports = {PreparedStatementError};

--- a/lib/errors/query-file-error.js
+++ b/lib/errors/query-file-error.js
@@ -10,7 +10,8 @@
 const npm = {
     os: require('os'),
     utils: require('../utils'),
-    minify: require('pg-minify')
+    minify: require('pg-minify'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -59,37 +60,16 @@ class QueryFileError extends Error {
     }
 }
 
-/**
- * @method errors.QueryFileError#toString
- * @description
- * Creates a well-formatted multi-line string that represents the error.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-QueryFileError.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        lines = [
-            'QueryFileError {',
-            gap1 + 'message: "' + this.message + '"',
-            gap1 + 'options: ' + npm.utils.toJson(this.options),
-            gap1 + 'file: "' + this.file + '"'
-        ];
-    if (this.error) {
-        lines.push(gap1 + 'error: ' + this.error.toString(level + 1));
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
 npm.utils.addInspection(QueryFileError, function () {
-    return this.toString();
+    const obj = {
+        message: this.message,
+        file: this.file,
+        options: this.options
+    };
+    if (this.error) {
+        obj.error = this.error;
+    }
+    return 'QueryFileError ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 module.exports = {QueryFileError};

--- a/lib/errors/query-result-error.js
+++ b/lib/errors/query-result-error.js
@@ -10,7 +10,8 @@
 const npm = {
     os: require('os'),
     utils: require('../utils'),
-    text: require('../text')
+    text: require('../text'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -102,7 +103,7 @@ const errorMessages = [
  *   error(err, e) {
  *       if (err instanceof QueryResultError) {
  *           // A query returned unexpected number of records, and thus rejected;
- *           
+ *
  *           // we can check the error code, if we want specifics:
  *           if(err.code === qrec.noData) {
  *               // expected some data, but received none;
@@ -112,7 +113,7 @@ const errorMessages = [
  *           // you will get a nicely formatted output.
  *
  *           console.log(err);
- *           
+ *
  *           // See also: err, e.query, e.params, etc.
  *       }
  *   }
@@ -137,38 +138,17 @@ class QueryResultError extends Error {
     }
 }
 
-/**
- * @method errors.QueryResultError#toString
- * @description
- * Creates a well-formatted multi-line string that represents the error.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-QueryResultError.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        lines = [
-            'QueryResultError {',
-            gap1 + 'code: queryResultErrorCode.' + errorMessages[this.code].name,
-            gap1 + 'message: "' + this.message + '"',
-            gap1 + 'received: ' + this.received,
-            gap1 + 'query: ' + (typeof this.query === 'string' ? '"' + this.query + '"' : npm.utils.toJson(this.query))
-        ];
-    if (this.values !== undefined) {
-        lines.push(gap1 + 'values: ' + npm.utils.toJson(this.values));
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
 npm.utils.addInspection(QueryResultError, function () {
-    return this.toString();
+    const obj = {
+        code: 'queryResultErrorCode.' + errorMessages[this.code].name,
+        message: this.message,
+        received: this.received,
+        query: typeof this.query === 'string' ? this.query : npm.utils.toJson(this.query)
+    };
+    if (this.values !== undefined) {
+        obj.values = this.values;
+    }
+    return 'QueryResultError ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 module.exports = {

--- a/lib/helpers/column-set.js
+++ b/lib/helpers/column-set.js
@@ -611,43 +611,4 @@ function colDesc(column, source) {
     return a;
 }
 
-/**
- * @method helpers.ColumnSet#toString
- * @description
- * Creates a well-formatted multi-line string that represents the object.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-ColumnSet.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        lines = [
-            'ColumnSet {'
-        ];
-    if (this.table) {
-        lines.push(gap1 + 'table: ' + this.table);
-    }
-    if (this.columns.length) {
-        lines.push(gap1 + 'columns: [');
-        this.columns.forEach(c => {
-            lines.push(c.toString(2));
-        });
-        lines.push(gap1 + ']');
-    } else {
-        lines.push(gap1 + 'columns: []');
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
-npm.utils.addInspection(ColumnSet, function () {
-    return this.toString();
-});
-
 module.exports = {ColumnSet};

--- a/lib/helpers/column.js
+++ b/lib/helpers/column.js
@@ -290,55 +290,6 @@ function isValidVariable(name) {
 }
 
 /**
- * @method helpers.Column#toString
- * @description
- * Creates a well-formatted multi-line string that represents the object.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-Column.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap0 = npm.utils.messageGap(level),
-        gap1 = npm.utils.messageGap(level + 1),
-        lines = [
-            gap0 + 'Column {',
-            gap1 + 'name: ' + npm.utils.toJson(this.name)
-        ];
-    if ('prop' in this) {
-        lines.push(gap1 + 'prop: ' + npm.utils.toJson(this.prop));
-    }
-    if ('mod' in this) {
-        lines.push(gap1 + 'mod: ' + npm.utils.toJson(this.mod));
-    }
-    if ('cast' in this) {
-        lines.push(gap1 + 'cast: ' + npm.utils.toJson(this.cast));
-    }
-    if ('cnd' in this) {
-        lines.push(gap1 + 'cnd: ' + npm.utils.toJson(this.cnd));
-    }
-    if ('def' in this) {
-        lines.push(gap1 + 'def: ' + npm.utils.toJson(this.def));
-    }
-    if ('init' in this) {
-        lines.push(gap1 + 'init: [Function]');
-    }
-    if ('skip' in this) {
-        lines.push(gap1 + 'skip: [Function]');
-    }
-    lines.push(gap0 + '}');
-    return lines.join(npm.os.EOL);
-};
-
-npm.utils.addInspection(Column, function () {
-    return this.toString();
-});
-
-/**
  * @typedef helpers.ColumnConfig
  * @description
  * A simple structure with column details, to be passed into the {@link helpers.Column Column} constructor for initialization.

--- a/lib/helpers/table-name.js
+++ b/lib/helpers/table-name.js
@@ -110,23 +110,6 @@ TableName.prototype[npm.format.ctf.toPostgres] = function (self) {
 TableName.prototype[npm.format.ctf.rawType] = true; // use as pre-formatted
 
 /**
- * @method helpers.TableName#toString
- * @description
- * Creates a well-formatted string that represents the object.
- *
- * It is called automatically when writing the object into the console.
- *
- * @returns {string}
- */
-TableName.prototype.toString = function () {
-    return this.name;
-};
-
-npm.utils.addInspection(TableName, function () {
-    return this.toString();
-});
-
-/**
  * @interface Table
  * @description
  * Structure for any table name/path.

--- a/lib/query-file.js
+++ b/lib/query-file.js
@@ -18,7 +18,8 @@ const npm = {
     path: require('path'),
     minify: require('pg-minify'),
     utils: require('./utils'),
-    formatting: require('./formatting')
+    formatting: require('./formatting'),
+    inspect: require('util').inspect
 };
 
 const file$query = Symbol('QueryFile.query');
@@ -312,38 +313,18 @@ QueryFile.prototype[npm.formatting.as.ctf.toPostgres] = function (self) {
 
 QueryFile.prototype[npm.formatting.as.ctf.rawType] = true; // use as pre-formatted
 
-/**
- * @method QueryFile#toString
- * @description
- * Creates a well-formatted multi-line string that represents the object's current state.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-QueryFile.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap = npm.utils.messageGap(level + 1);
-    const lines = [
-        'QueryFile {'
-    ];
-    this.prepare();
-    lines.push(gap + 'file: "' + this.file + '"');
-    lines.push(gap + 'options: ' + npm.utils.toJson(this.options));
-    if (this.error) {
-        lines.push(gap + 'error: ' + this.error.toString(level + 1));
-    } else {
-        lines.push(gap + 'query: "' + this[QueryFile.$query] + '"');
-    }
-    lines.push(npm.utils.messageGap(level) + '}');
-    return lines.join(npm.os.EOL);
-};
-
 npm.utils.addInspection(QueryFile, function () {
-    return this.toString();
+    const s = 'QueryFile ';
+    const obj = {
+        file: this.file,
+        options: this.options
+    };
+    this.prepare();
+    if (this.error) {
+        obj.error = this.error;
+    }
+    obj.query = this[QueryFile.$query];
+    return s + npm.inspect(obj, {depth: 5, colors: true});
 });
 
 module.exports = {QueryFile};

--- a/lib/query-file.js
+++ b/lib/query-file.js
@@ -324,7 +324,7 @@ npm.utils.addInspection(QueryFile, function () {
         obj.error = this.error;
     }
     obj.query = this[QueryFile.$query];
-    return s + npm.inspect(obj, {depth: 5, colors: true});
+    return s + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 module.exports = {QueryFile};

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,0 @@
-const {QueryResultError} = require('./errors');
-
-const a = new QueryResultError(2, {rows:[{}]}, 'some-query', [1,2,3]);
-
-// eslint-disable-next-line
-console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,5 +1,8 @@
-const {TableName} = require('./helpers/table-name');
+const {Column} = require('./helpers/column');
 
-const a = new TableName({table: 'hello', schema: 'public'});
+const a = new Column({
+    name: 'test',
+    mod: '^'
+});
 
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,6 @@
-const {PreparedStatementError} = require('./errors');
+const {QueryFileError} = require('./errors');
 
-const a = new PreparedStatementError(new Error('Ops!'), {text: 'bla', values: ['a'], name: 'hello'});
+const a = new QueryFileError(new Error('Ops!'), {file:'.bla/sql', options:123});
 
 // eslint-disable-next-line
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,6 @@
-const {ParameterizedQueryError} = require('./errors');
+const {PreparedStatementError} = require('./errors');
 
-const a = new ParameterizedQueryError(new Error('Ops! is ok to be one one line'), {text: 'bla', values: ['a']});
+const a = new PreparedStatementError(new Error('Ops!'), {text: 'bla', values: ['a'], name: 'hello'});
 
 // eslint-disable-next-line
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,5 +1,6 @@
-const {QueryFile} = require('./query-file');
+const {ParameterizedQueryError} = require('./errors');
 
-const a = new QueryFile('../test/sql/allUsers.sql', {minify: true});
+const a = new ParameterizedQueryError(new Error('Ops! is ok to be one one line'), {text: 'bla', values: ['a']});
 
+// eslint-disable-next-line
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,10 +1,5 @@
-const {ColumnSet} = require('./helpers/column-set');
+const {TransactionMode, isolationLevel} = require('./tx-mode');
 
-const a = new ColumnSet([{name: 'one', mod: '^'}, {name: 'two', mod: '#', skip: () => false}], {
-    table: {
-        table: 'main',
-        schema: 'public'
-    }
-});
+const a = new TransactionMode({tiLevel: isolationLevel.serializable});
 
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,5 +1,5 @@
-const {TransactionMode, isolationLevel} = require('./tx-mode');
+const {QueryFile} = require('./query-file');
 
-const a = new TransactionMode({tiLevel: isolationLevel.serializable});
+const a = new QueryFile('../test/sql/allUsers.sql', {minify: true});
 
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,8 +1,10 @@
-const {Column} = require('./helpers/column');
+const {ColumnSet} = require('./helpers/column-set');
 
-const a = new Column({
-    name: 'test',
-    mod: '^'
+const a = new ColumnSet([{name: 'one', mod: '^'}, {name: 'two', mod: '#', skip: () => false}], {
+    table: {
+        table: 'main',
+        schema: 'public'
+    }
 });
 
 console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,0 +1,5 @@
+const {TableName} = require('./helpers/table-name');
+
+const a = new TableName({table: 'hello', schema: 'public'});
+
+console.log(a);

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,6 @@
-const {QueryFileError} = require('./errors');
+const {QueryResultError} = require('./errors');
 
-const a = new QueryFileError(new Error('Ops!'), {file:'.bla/sql', options:123});
+const a = new QueryResultError(2, {rows:[{}]}, 'some-query', [1,2,3]);
 
 // eslint-disable-next-line
 console.log(a);

--- a/lib/tx-mode.js
+++ b/lib/tx-mode.js
@@ -162,7 +162,9 @@ class TransactionMode extends InnerState {
 }
 
 addInspection(TransactionMode, function () {
-    return this.begin(true);
+    return {
+        TransactionMode: this.begin(true)
+    };
 });
 
 /**
@@ -187,4 +189,3 @@ module.exports = {
     isolationLevel,
     TransactionMode
 };
-

--- a/lib/tx-mode.js
+++ b/lib/tx-mode.js
@@ -8,8 +8,12 @@
  */
 
 const {InnerState} = require('./inner-state');
-const {addInspection} = require('./utils');
 const {assert} = require('./assert');
+
+const npm = {
+    addInspection: require('./utils').addInspection,
+    inspect: require('util').inspect
+};
 
 /**
  * @enum {number}
@@ -22,7 +26,7 @@ const {assert} = require('./assert');
  * @see $[Transaction Isolation]
  */
 const isolationLevel = {
-    /** Isolation level not specified. */
+    /** Isolation level isn't specified. */
     none: 0,
 
     /** `ISOLATION LEVEL SERIALIZABLE` */
@@ -161,10 +165,9 @@ class TransactionMode extends InnerState {
     }
 }
 
-addInspection(TransactionMode, function () {
-    return {
-        TransactionMode: this.begin(true)
-    };
+npm.addInspection(TransactionMode, function () {
+    const obj = {SQL: this.begin(true)};
+    return 'TransactionMode ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
 });
 
 /**

--- a/lib/types/parameterized-query.js
+++ b/lib/types/parameterized-query.js
@@ -14,7 +14,8 @@ const {assert} = require('../assert');
 
 const npm = {
     EOL: require('os').EOL,
-    utils: require('../utils')
+    utils: require('../utils'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -162,43 +163,26 @@ ParameterizedQuery.prototype.parse = function () {
     return _i.target;
 };
 
-/**
- * @method ParameterizedQuery#toString
- * @description
- * Creates a well-formatted multi-line string that represents the object's current state.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-ParameterizedQuery.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap = npm.utils.messageGap(level + 1);
+npm.utils.addInspection(ParameterizedQuery, function () {
     const pq = this.parse();
-    const lines = [
-        'ParameterizedQuery {'
-    ];
+    const obj = {};
     if (npm.utils.isText(pq.text)) {
-        lines.push(gap + 'text: "' + pq.text + '"');
+        obj.text = pq.text;
     }
     if (this.values !== undefined) {
-        lines.push(gap + 'values: ' + npm.utils.toJson(this.values));
+        obj.values = this.values;
     }
     if (this.binary !== undefined) {
-        lines.push(gap + 'binary: ' + npm.utils.toJson(this.binary));
+        obj.binary = this.binary;
     }
     if (this.rowMode !== undefined) {
-        lines.push(gap + 'rowMode: ' + npm.utils.toJson(this.rowMode));
+        obj.rowMode = this.rowMode;
     }
     if (this.error !== undefined) {
-        lines.push(gap + 'error: ' + this.error.toString(level + 1));
+        obj.error = this.error.message;
     }
-    lines.push(npm.utils.messageGap(level) + '}');
-    return lines.join(npm.EOL);
-};
+    return 'ParameterizedQuery ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
+});
 
 module.exports = {ParameterizedQuery};
 

--- a/lib/types/prepared-statement.js
+++ b/lib/types/prepared-statement.js
@@ -14,7 +14,8 @@ const {assert} = require('../assert');
 
 const npm = {
     EOL: require('os').EOL,
-    utils: require('../utils')
+    utils: require('../utils'),
+    inspect: require('util').inspect
 };
 
 /**
@@ -206,47 +207,31 @@ PreparedStatement.prototype.parse = function () {
     return _i.target;
 };
 
-/**
- * @method PreparedStatement#toString
- * @description
- * Creates a well-formatted multi-line string that represents the object's current state.
- *
- * It is called automatically when writing the object into the console.
- *
- * @param {number} [level=0]
- * Nested output level, to provide visual offset.
- *
- * @returns {string}
- */
-PreparedStatement.prototype.toString = function (level) {
-    level = level > 0 ? parseInt(level) : 0;
-    const gap = npm.utils.messageGap(level + 1);
-    const ps = this.parse();
-    const lines = [
-        'PreparedStatement {',
-        gap + 'name: ' + npm.utils.toJson(this.name)
-    ];
-    if (npm.utils.isText(ps.text)) {
-        lines.push(gap + 'text: "' + ps.text + '"');
+npm.utils.addInspection(PreparedStatement, function () {
+    const pq = this.parse();
+    const obj = {
+        name: this.name
+    };
+    if (npm.utils.isText(pq.text)) {
+        obj.text = pq.text;
     }
     if (this.values !== undefined) {
-        lines.push(gap + 'values: ' + npm.utils.toJson(this.values));
+        obj.values = this.values;
     }
     if (this.binary !== undefined) {
-        lines.push(gap + 'binary: ' + npm.utils.toJson(this.binary));
+        obj.binary = this.binary;
     }
     if (this.rowMode !== undefined) {
-        lines.push(gap + 'rowMode: ' + npm.utils.toJson(this.rowMode));
+        obj.rowMode = this.rowMode;
     }
     if (this.rows !== undefined) {
-        lines.push(gap + 'rows: ' + npm.utils.toJson(this.rows));
+        obj.rows = this.rows;
     }
-    if (this.error) {
-        lines.push(gap + 'error: ' + this.error.toString(level + 1));
+    if (this.error !== undefined) {
+        obj.error = this.error.message;
     }
-    lines.push(npm.utils.messageGap(level) + '}');
-    return lines.join(npm.EOL);
-};
+    return 'PreparedStatement ' + npm.inspect(obj, {breakLength: 100, depth: 5, colors: true});
+});
 
 module.exports = {PreparedStatement};
 

--- a/lib/types/server-formatting.js
+++ b/lib/types/server-formatting.js
@@ -1,5 +1,4 @@
 const {InnerState} = require('../inner-state');
-const {addInspection} = require('../utils');
 const utils = require('../utils');
 
 /**
@@ -89,9 +88,5 @@ function setValues(v) {
         }
     }
 }
-
-addInspection(ServerFormatting, function () {
-    return this.toString();
-});
 
 module.exports = {ServerFormatting};

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -73,12 +73,6 @@ function getSafeConnection(cn) {
     return maskPassword(cn);
 }
 
-///////////////////////////////////////////
-// Returns a space gap for console output;
-function messageGap(level) {
-    return ' '.repeat(level * 4);
-}
-
 /////////////////////////////////////////
 // Provides platform-neutral inheritance;
 function inherits(child, parent) {
@@ -193,7 +187,6 @@ const exp = {
     addReadProp,
     addReadProperties,
     getSafeConnection,
-    messageGap,
     inherits,
     isConnectivityError
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "jasmine-node --captureExceptions test",
     "test:init": "node test/db/init.js",
-    "test:native": "jasmine-node test --config PG_NATIVE true",
-    "start": "node ./lib/start.js"
+    "test:native": "jasmine-node test --config PG_NATIVE true"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "jasmine-node --captureExceptions test",
     "test:init": "node test/db/init.js",
-    "test:native": "jasmine-node test --config PG_NATIVE true"
+    "test:native": "jasmine-node test --config PG_NATIVE true",
+    "start": "node ./lib/start.js"
   },
   "files": [
     "lib",

--- a/test/db.spec.js
+++ b/test/db.spec.js
@@ -696,7 +696,6 @@ describe('Method \'none\'', () => {
             runs(() => {
                 expect(result).toBeUndefined();
                 expect(error instanceof pgp.errors.QueryResultError).toBe(true);
-                expect(error.toString(1) != tools.inspect(error)).toBe(true);
                 expect(error.message).toBe($text.notEmpty);
                 expect(error.result.rows.length).toBeGreaterThan(0);
             });
@@ -718,7 +717,6 @@ describe('Method \'none\'', () => {
             runs(() => {
                 expect(result).toBeUndefined();
                 expect(error instanceof pgp.errors.QueryResultError).toBe(true);
-                expect(error.toString(1) != tools.inspect(error)).toBe(true);
                 expect(error.message).toBe($text.notEmpty);
                 expect(error.result.rows.length).toBeGreaterThan(0);
             });

--- a/test/db.spec.js
+++ b/test/db.spec.js
@@ -5,7 +5,6 @@ const npm = {
 const capture = require('./db/capture');
 const pgResult = require('pg/lib/result');
 const header = require('./db/header');
-const tools = require('./db/tools');
 
 const isMac = npm.platform === 'darwin';
 const isWindows = npm.platform === 'win32';

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -153,7 +153,11 @@ describe('QueryFile / Positive:', () => {
     describe('inspect', () => {
         const qf = new QueryFile(sqlSimple, {noWarnings: true});
         it('must return the query', () => {
-            expect(tools.inspect(qf)).toBe(qf.toString());
+            const s = tools.inspect(qf);
+            expect(s.startsWith('QueryFile {')).toBe(true);
+            expect(s).toContain('file:');
+            expect(s).toContain('options:');
+            expect(s).toContain('query:');
         });
     });
 

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -220,9 +220,10 @@ describe('QueryFile / Negative:', () => {
     describe('inspect', () => {
         const qf = new QueryFile(sqlInvalid, {minify: true, noWarnings: true});
         it('must return the error', () => {
-            expect(tools.inspect(qf) != qf.toString(1)).toBe(true);
-            expect(qf.error instanceof QueryFileError).toBe(true);
-            expect(tools.inspect(qf.error)).toBe(qf.error.toString());
+            const s = tools.inspect(qf);
+            expect(s.startsWith('QueryFile {')).toBeTruthy();
+            expect(s).toContain('message:');
+            expect(s).toContain('options:');
         });
     });
 

--- a/test/help.spec.js
+++ b/test/help.spec.js
@@ -265,14 +265,6 @@ describe('TableName', () => {
         });
     });
 
-    describe('console output', () => {
-        it('must be formatted', () => {
-            const t = new helpers.TableName({table: 'table', schema: 'schema'});
-            expect(t.toString()).toBe('"schema"."table"');
-            expect(t.toString()).toBe(tools.inspect(t));
-        });
-    });
-
     describe('custom-type formatting', () => {
         const t = new helpers.TableName({table: 'table', schema: 'schema'});
         it('must return the full name', () => {
@@ -471,7 +463,7 @@ describe('ColumnSet', () => {
         it('must set table correctly', () => {
             const t = new helpers.TableName('table');
             const cs = new helpers.ColumnSet(['name'], {table: t});
-            expect(cs.table.toString()).toBe('"table"');
+            expect(cs.table.name).toBe('"table"');
         });
         it('must support inherited properties', () => {
             function A() {
@@ -720,19 +712,6 @@ describe('ColumnSet', () => {
             expect(() => {
                 new helpers.ColumnSet({}, 123);
             }).toThrow('Invalid "options" parameter: 123');
-        });
-    });
-
-    describe('console coverage', () => {
-        const cs1 = new helpers.ColumnSet(['name']);
-        const cs2 = new helpers.ColumnSet(['name'], {table: 'table'});
-        const cs3 = new helpers.ColumnSet([]);
-        const gap = utils.messageGap(1);
-        it('must cover all lines', () => {
-            expect(cs1.toString()).toContain('columns: [');
-            expect(cs2.toString()).toContain('table: "table"');
-            expect(cs3.toString()).toBe('ColumnSet {' + os.EOL + gap + 'columns: []' + os.EOL + '}');
-            expect(cs1.toString(1) !== tools.inspect(cs1)).toBe(true);
         });
     });
 

--- a/test/help.spec.js
+++ b/test/help.spec.js
@@ -300,7 +300,6 @@ describe('Column', () => {
             expect(col.mod).toBe('^');
             expect(typeof col.init).toBe('function');
             expect(typeof col.skip).toBe('function');
-            expect(col.toString()).toBe(tools.inspect(col));
         });
     });
 

--- a/test/help.spec.js
+++ b/test/help.spec.js
@@ -1,5 +1,4 @@
 const header = require('./db/header');
-const tools = require('./db/tools');
 
 const options = {
     capSQL: false,
@@ -7,7 +6,6 @@ const options = {
 };
 const pgp = header(options).pgp;
 
-const os = require('os');
 const path = require('path');
 const utils = require('../lib/utils');
 const helpers = pgp.helpers;

--- a/test/parameterized.spec.js
+++ b/test/parameterized.spec.js
@@ -35,7 +35,7 @@ describe('ParameterizedQuery', () => {
             expect(pq.values).toBe(values);
             expect(pq.binary).toBe(true);
             expect(pq.rowMode).toBe('array');
-            expect(tools.inspect(pq)).toBe(pq.toString());
+            expect(tools.inspect(pq)).toContain('original-sql');
         });
         it('must keep original object when set to the same value', () => {
             const pq = new pgp.ParameterizedQuery({
@@ -51,7 +51,7 @@ describe('ParameterizedQuery', () => {
             pq.rowMode = 'array';
             const obj2 = pq.parse();
             expect(obj1 === obj2).toBe(true);
-            expect(tools.inspect(pq)).toBe(pq.toString());
+            expect(tools.inspect(pq)).toContain('original-sql');
         });
         it('must create a new object when changed', () => {
             const pq = new pgp.ParameterizedQuery({
@@ -70,7 +70,7 @@ describe('ParameterizedQuery', () => {
             pq.rowMode = 'new';
             const obj5 = pq.parse();
             expect(obj1 !== obj2 !== obj3 !== obj4 != obj5).toBe(true);
-            expect(tools.inspect(pq)).toBe(pq.toString());
+            expect(tools.inspect(pq)).toContain('new text');
         });
     });
 
@@ -138,8 +138,8 @@ describe('ParameterizedQuery', () => {
         const pq1 = new pgp.ParameterizedQuery('test-query $1');
         const pq2 = new pgp.ParameterizedQuery('test-query $1', []);
         it('must stringify all values', () => {
-            expect(tools.inspect(pq1)).toBe(pq1.toString());
-            expect(tools.inspect(pq2)).toBe(pq2.toString());
+            expect(tools.inspect(pq1)).toContain('test-query $1');
+            expect(tools.inspect(pq2)).toContain('test-query $1');
         });
     });
 
@@ -152,7 +152,6 @@ describe('ParameterizedQuery', () => {
             const result = pq.parse();
             expect(result && typeof result === 'object').toBeTruthy();
             expect(result.text).toBe('select 1;');
-            expect(pq.toString()).toBe(tools.inspect(pq));
         });
 
         describe('with an error', () => {
@@ -161,8 +160,6 @@ describe('ParameterizedQuery', () => {
             const result = pq.parse();
             expect(result instanceof ParameterizedQueryError).toBe(true);
             expect(result.error instanceof pgp.errors.QueryFileError).toBe(true);
-            expect(pq.toString()).toBe(tools.inspect(pq));
-            expect(pq.toString(1) !== tools.inspect(pq)).toBe(true);
         });
 
     });

--- a/test/parameterized.spec.js
+++ b/test/parameterized.spec.js
@@ -235,7 +235,10 @@ describe('Direct Parameterized Query', () => {
         });
         it('must return an error', () => {
             expect(result instanceof pgp.errors.ParameterizedQueryError).toBe(true);
-            expect(result.toString()).toBe(tools.inspect(result));
+            const s = tools.inspect(result);
+            expect(s.startsWith('ParameterizedQueryError {')).toBeTruthy();
+            expect(s).toContain('message:');
+            expect(s).toContain('result:');
         });
     });
 

--- a/test/prepared.spec.js
+++ b/test/prepared.spec.js
@@ -261,8 +261,10 @@ describe('Direct Prepared Statements', () => {
         });
         it('must return an error', () => {
             expect(result instanceof PreparedStatementError).toBe(true);
-            expect(ps.toString(1) != tools.inspect(ps)).toBe(true);
-            expect(result.toString()).toBe(tools.inspect(result));
+            const s = tools.inspect(result);
+            expect(s.startsWith('PreparedStatementError {')).toBeTruthy();
+            expect(s).toContain('message:');
+            expect(s).toContain('result:');
         });
     });
 

--- a/test/prepared.spec.js
+++ b/test/prepared.spec.js
@@ -37,7 +37,7 @@ describe('PreparedStatement', () => {
             expect(ps.binary).toBe(true);
             expect(ps.rowMode).toBe('array');
             expect(ps.rows).toBe(1);
-            expect(tools.inspect(ps)).toBe(ps.toString());
+            expect(tools.inspect(ps)).toContain('original-sql');
         });
         it('must keep original object when set to the same value', () => {
             const ps = new pgp.PreparedStatement({
@@ -57,7 +57,7 @@ describe('PreparedStatement', () => {
             ps.rows = 1;
             const obj2 = ps.parse();
             expect(obj1 === obj2).toBe(true);
-            expect(tools.inspect(ps)).toBe(ps.toString());
+            expect(tools.inspect(ps)).toContain('original-sql');
         });
         it('must create a new object when changed', () => {
             const ps = new pgp.PreparedStatement({
@@ -82,7 +82,8 @@ describe('PreparedStatement', () => {
             ps.rows = 3;
             const obj7 = ps.parse();
             expect(obj1 !== obj2 !== obj3 !== obj4 != obj5 != obj6 != obj7).toBe(true);
-            expect(tools.inspect(ps)).toBe(ps.toString());
+            const s = tools.inspect(ps);
+            expect(s).toContain('new value');
         });
     });
 
@@ -142,11 +143,9 @@ describe('PreparedStatement', () => {
     });
 
     describe('object inspection', () => {
-        const ps1 = new pgp.PreparedStatement({name: 'test-name', text: 'test-query $1'});
-        const ps2 = new pgp.PreparedStatement({name: 'test-name', text: 'test-query $1', values: [123]});
-        it('must stringify all values', () => {
-            expect(tools.inspect(ps1)).toBe(ps1.toString());
-            expect(tools.inspect(ps2)).toBe(ps2.toString());
+        const ps = new pgp.PreparedStatement({name: 'test-name', text: 'test-query $1'});
+        it('must stringify values', () => {
+            expect(tools.inspect(ps)).toContain('test-query $1');
         });
     });
 
@@ -160,7 +159,7 @@ describe('PreparedStatement', () => {
             expect(result && typeof result === 'object').toBeTruthy();
             expect(result.name).toBe('test-name');
             expect(result.text).toBe('select 1;');
-            expect(ps.toString()).toBe(tools.inspect(ps));
+            expect(tools.inspect(ps)).toContain('select 1;');
         });
 
         describe('with error', () => {
@@ -169,7 +168,6 @@ describe('PreparedStatement', () => {
             const result = ps.parse();
             expect(result instanceof pgp.errors.PreparedStatementError).toBe(true);
             expect(result.error instanceof pgp.errors.QueryFileError).toBe(true);
-            expect(ps.toString()).toBe(tools.inspect(ps));
         });
     });
 

--- a/test/protocol.spec.js
+++ b/test/protocol.spec.js
@@ -492,8 +492,19 @@ describe('Error protocol', () => {
     };
     it('must return correctly formatted error body', () => {
         const error1 = new pgp.errors.QueryResultError(0, result, '');
+        const s1 = tools.inspect(error1);
+        expect(s1.startsWith('QueryResultError {')).toBeTruthy();
+        expect(s1).toContain('message:');
+        expect(s1).toContain('received:');
+        expect(s1).toContain('query:');
+
         const error2 = new pgp.errors.QueryResultError(0, result, {name: 'name', text: 'text'}, []);
-        expect(tools.inspect(error1)).toBe(error1.toString());
-        expect(tools.inspect(error2)).toBe(error2.toString());
+
+        const s2 = tools.inspect(error2);
+        expect(s2.startsWith('QueryResultError {')).toBeTruthy();
+        expect(s2).toContain('message:');
+        expect(s2).toContain('received:');
+        expect(s2).toContain('query:');
+        expect(s2).toContain('{"name":"name","text":"text"}');
     });
 });

--- a/test/tx-mode.spec.js
+++ b/test/tx-mode.spec.js
@@ -265,8 +265,8 @@ describe('TransactionMode', () => {
 
     describe('inspection', () => {
         const mode = new TransactionMode();
-        it('must return the same as method begin()', () => {
-            expect(mode.begin(true)).toBe(tools.inspect(mode));
+        it('must return an object with class name + SQL', () => {
+            expect(tools.inspect(mode)).toEqual({TransactionMode: mode.begin(true)});
         });
     });
 });

--- a/test/tx-mode.spec.js
+++ b/test/tx-mode.spec.js
@@ -266,7 +266,8 @@ describe('TransactionMode', () => {
     describe('inspection', () => {
         const mode = new TransactionMode();
         it('must return an object with class name + SQL', () => {
-            expect(tools.inspect(mode)).toEqual({TransactionMode: mode.begin(true)});
+            expect(tools.inspect(mode).startsWith('TransactionMode {')).toBeTruthy();
+            expect(tools.inspect(mode)).toContain(mode.begin(true));
         });
     });
 });


### PR DESCRIPTION
This removes legacy inspections from all classes, because the modern NodeJS object inspections are better now.
